### PR TITLE
fix(env): Use exact 'win32' process.platform check

### DIFF
--- a/src/core/Utils/environment.js
+++ b/src/core/Utils/environment.js
@@ -12,7 +12,7 @@ if (globalThis?.location?.origin) {
     NODE = !BROWSER
 }
 
-if (globalThis?.process?.platform?.includes("win")) WIN = true
+if (globalThis?.process?.platform === "win32") WIN = true
 
 const DEV = BROWSER && globalThis?.location?.hostname === "localhost"
 


### PR DESCRIPTION
Replace a substring check of process.platform with a strict equality to 'win32' to more accurately detect Windows in Node. This prevents false positives from other platform strings containing "win" like MacOS with "darwin" and aligns with Node's documented platform value.