### PR TITLE
fix: conditional routes, 404, and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ CLAUDE.md
 /src/statics/forex.yaml
 /games/
 
-# BMAD
-_bmad/
+# BMADT
 _bmad-output/
+_bmad/
 .cursor/

--- a/builder/core.js
+++ b/builder/core.js
@@ -166,7 +166,7 @@ for (const name of itemDirs) {
         // No meta.yaml → check if it's a game namespace containing item subdirs
         const subDirs = await dir([...paths.src.items, name])
         const nested = []
-        for (const sub of subDirs) {
+        for (const sub of subDirs)
             if (await isDirectory([...paths.src.items, name, sub])) {
                 const subMeta = await load([...paths.src.items, name, sub, "meta.yaml"])
                 if (subMeta) {
@@ -174,7 +174,6 @@ for (const name of itemDirs) {
                     normalizeTags(subMeta.tags).forEach((tag) => allTags.add(tag))
                 }
             }
-        }
         if (nested.length > 0) gameItemsMap[name] = nested
     }
 }
@@ -219,13 +218,8 @@ log.ok(`Built ${domainCount} domain mappings`)
 
 // Build core-managed items (YAML → JSON, flat structure only)
 log.info("Building core-managed items (YAML → JSON)...")
-for (const itemId of coreItems) {
-    await processYamlDirectory(
-        [...paths.src.items, itemId],
-        [...paths.build.statics, "items", itemId],
-        { recursive: false }
-    )
-}
+for (const itemId of coreItems) await processYamlDirectory([...paths.src.items, itemId], [...paths.build.statics, "items", itemId], { recursive: false })
+
 for (const itemId of coreItems) {
     const metaPath = [...paths.build.statics, "items", itemId, "meta.json"]
     const meta = await load(metaPath)
@@ -255,9 +249,8 @@ if (await exist(itemsRoot)) {
             await remove([...itemsRoot, entry])
             continue
         }
-        if (entry === "meta.json" || /^\d+\.json$/.test(entry)) {
-            await remove([...itemsRoot, entry])
-        }
+        if (entry === "meta.json" || /^\d+\.json$/.test(entry)) await remove([...itemsRoot, entry])
+        
     }
 }
 
@@ -375,17 +368,30 @@ log.info("Processing i18n files...")
 const localeCount = await processI18n(locales)
 log.ok(`Created ${localeCount} locale files`)
 
-// Generate routes — always skipDynamic, SPA fallback handles dynamic routes
-// Dev: dev server serves index.html for unmatched extensionless URLs
-// Production: Netlify _redirects handles SPA fallback
-log.info("Generating routes (static prefixes only)...")
+// Generate routes
+// Dev: static prefixes only, dev server SPA fallback handles dynamic routes
+// Netlify: static prefixes only + _redirects for SPA fallback (faster deploy)
+// Other production: build all static files
+const devMode = process.argv.includes("--dev")
+const isNetlify = process.env.NETLIFY === "true"
+const skipDynamic = devMode || isNetlify
+
+if (isNetlify) log.info("Detected Netlify — static prefixes + _redirects...")
+else if (devMode) log.info("Generating routes (dev — SPA mode)...")
+else log.info("Generating routes (all static files)...")
+
 const indexContent = await load(paths.src.index)
-const routeCount = await generateRoutes(locales, coreItems, [], games, indexContent, "build", routeDirs, gameItemsMap, { skipDynamic: true })
+const routeCount = await generateRoutes(locales, coreItems, [], games, indexContent, "build", routeDirs, gameItemsMap, { skipDynamic })
 log.ok(`Created ${routeCount} route files`)
 
-// Generate _redirects for Netlify SPA fallback
-await write([...paths.build.root, "_redirects"], "/*  /index.html  200\n")
-log.ok("Created _redirects for Netlify SPA fallback")
+if (isNetlify) {
+    await write([...paths.build.root, "_redirects"], "/*  /index.html  200\n")
+    log.ok("Created _redirects for Netlify SPA fallback")
+}
+
+// 404.html — platform-agnostic SPA fallback for unknown routes
+await write([...paths.build.root, "404.html"], indexContent)
+log.ok("Created 404.html fallback")
 
 // Note: geo data is built separately via npm run geo:build to build/geo/
 

--- a/dev.js
+++ b/dev.js
@@ -228,6 +228,7 @@ async function loadHttpsCredentials() {
 
 async function resolveBuildFile(urlPathname) {
     const pathname = decodeURIComponent(urlPathname)
+    const extensionlessRequest = !path.extname(pathname)
     let requestPath = pathname === "/" ? "/index.html" : pathname
     if (requestPath.endsWith("/")) requestPath += "index.html"
 
@@ -246,7 +247,7 @@ async function resolveBuildFile(urlPathname) {
         return absolutePath
     }
 
-    if (!path.extname(absolutePath)) {
+    if (extensionlessRequest) {
         const htmlPath = `${absolutePath}.html`
         if (await exists(htmlPath)) return htmlPath
         const indexPath = path.join(absolutePath, "index.html")

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "mimiza",
   "type": "module",
   "scripts": {
-    "start": "node build.js core && node dev.js",
+    "start": "node build.js core --dev && node dev.js",
     "build": "node build.js crypto && node build.js core && node build.js index && node build.js geo && node build.js hash",
     "build:core": "node build.js core",
     "build:index": "node build.js index",


### PR DESCRIPTION
Detect dev and Netlify modes to control route generation: add devMode/isNetlify flags, pass skipDynamic to generateRoutes, and emit _redirects only on Netlify. Always write a 404.html SPA fallback. Tweak dev server to correctly detect extensionless requests. Minor code cleanups in builder/core.js (condense loops/awaits, tidy removal logic) and update package.json start script to run core build in --dev mode. Update .gitignore ordering/comments and ensure .cursor and _bmad entries are present.