### PR TITLE
feat(profile): Gun-backed following, avatar picker, bio UX, link sanitization

### DIFF
--- a/src/UI/components/avatars/index.js
+++ b/src/UI/components/avatars/index.js
@@ -42,7 +42,6 @@ export class AVATARS extends HTMLElement {
         this.subscriptions.push(
             this.$identicons.events.on("select", ({ detail: { id } }) => { this.id = id }),
             this.$identicons.events.on("increase", () => { this.total += this.step }),
-            this.$identicons.events.on("decrease", () => { if (this.total - this.step > this.id) this.total -= this.step }),
             Access.on("authenticated", async ({ value }) => {
                 this.style.display = value ? "flex" : "none"
                 if (value) { await seed(); this.render() }

--- a/src/UI/components/avatars/styles.css.js
+++ b/src/UI/components/avatars/styles.css.js
@@ -3,9 +3,15 @@ import { css } from "/core/UI.js"
 export const styles = css`
     :host {
         width: 100%;
+        height: 100%;
         display: flex;
         flex-direction: column;
         gap: var(--space);
+
+        ui-identicons {
+            flex: 1;
+            min-height: 0;
+        }
     }
 `
 

--- a/src/UI/components/avatars/template.js
+++ b/src/UI/components/avatars/template.js
@@ -1,13 +1,10 @@
 import "/UI/components/identicons/index.js"
-import "/UI/components/context/index.js"
 import styles from "./styles.css.js"
 import { html } from "/core/UI.js"
 
 export const template = html`
     ${styles}
-    <ui-identicons data-name="avatar" data-size="7">
-        <ui-context data-key="dictionary.avatars" />
-    </ui-identicons>
+    <ui-identicons data-name="avatar" data-size="7"></ui-identicons>
 `
 
 export default template

--- a/src/UI/components/identicons/index.js
+++ b/src/UI/components/identicons/index.js
@@ -11,6 +11,7 @@ export class IDENTICONS extends HTMLElement {
         this.$id = 0
         this.$total = 0
         this.$renderPending = false
+        this._loadingMore = false
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
     }
@@ -32,16 +33,19 @@ export class IDENTICONS extends HTMLElement {
 
     connectedCallback() {
         this.$container = this.shadowRoot.querySelector("#container")
-        const increase = () => this.events.emit("increase")
-        const decrease = () => this.events.emit("decrease")
-        const $increase = this.shadowRoot.querySelector("#increase")
-        const $decrease = this.shadowRoot.querySelector("#decrease")
-        $increase.addEventListener("click", increase)
-        $decrease.addEventListener("click", decrease)
-        this.subscriptions.push(
-            () => $increase.removeEventListener("click", increase),
-            () => $decrease.removeEventListener("click", decrease)
-        )
+
+        const onScroll = () => {
+            if (this._loadingMore) return
+            const { scrollLeft, scrollWidth, clientWidth } = this.$container
+            if (scrollWidth - scrollLeft - clientWidth < clientWidth * 0.5) {
+                this._loadingMore = true
+                this.events.emit("increase")
+                setTimeout(() => { this._loadingMore = false }, 600)
+            }
+        }
+
+        this.$container.addEventListener("scroll", onScroll, { passive: true })
+        this.subscriptions.push(() => this.$container.removeEventListener("scroll", onScroll))
     }
 
     disconnectedCallback() {
@@ -81,7 +85,10 @@ export class IDENTICONS extends HTMLElement {
         }
         render(templates, this.$container, { append: true })
         const input = this.$container.querySelector(`input#i${this.$id}`)
-        if (input) input.checked = true
+        if (input) {
+            input.checked = true
+            input.closest(".item")?.scrollIntoView({ behavior: "instant", block: "nearest", inline: "center" })
+        }
     }
 
     remove() {

--- a/src/UI/components/identicons/styles.css.js
+++ b/src/UI/components/identicons/styles.css.js
@@ -2,47 +2,92 @@ import { css } from "/core/UI.js"
 
 export const styles = css`
     :host {
+        display: block;
         width: 100%;
+        height: 100%;
+        position: relative;
+    }
+
+    #container {
+        width: 100%;
+        height: 100%;
         display: flex;
-        flex-direction: column;
-        gap: var(--space);
-        header {
-            --icon: var(--icon-md);
-            width: 100%;
-            display: inline-flex;
-            justify-content: space-between;
-            align-items: center;
-            text-transform: uppercase;
-            nav {
-                display: inline-flex;
-                gap: var(--space);
+        flex-direction: row;
+        align-items: center;
+        gap: var(--space-3);
+        overflow-x: auto;
+        scroll-snap-type: x mandatory;
+        scroll-behavior: smooth;
+        /* vertical padding absorbs the scale(1.2) of selected item */
+        padding: var(--identicons-pad-v, var(--space-4)) var(--space-5);
+        box-sizing: border-box;
+
+        /* hide scrollbar cross-browser */
+        scrollbar-width: none;
+        &::-webkit-scrollbar { display: none; }
+
+        /* edge fade — items dissolve into background at both sides */
+        mask-image: linear-gradient(
+            to right,
+            transparent 0,
+            black var(--space-5),
+            black calc(100% - var(--space-5)),
+            transparent 100%
+        );
+        -webkit-mask-image: linear-gradient(
+            to right,
+            transparent 0,
+            black var(--space-5),
+            black calc(100% - var(--space-5)),
+            transparent 100%
+        );
+
+        .item {
+            flex-shrink: 0;
+            scroll-snap-align: center;
+            width: var(--icon-lg);
+            height: var(--icon-lg);
+
+            input[type="radio"] {
+                display: none;
+
+                &:checked + label {
+                    color: var(--neon-c);
+                    opacity: 1;
+                    transform: scale(1.2);
+                    outline: 1px solid color-mix(in hsl, var(--neon-c) 70%, transparent);
+                    outline-offset: var(--space-1);
+                    box-shadow: var(--glow-c);
+                }
+            }
+
+            label {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: 100%;
+                height: 100%;
+                cursor: pointer;
+                color: var(--color);
+                opacity: 0.4;
+                transition:
+                    opacity var(--speed),
+                    transform var(--speed),
+                    color var(--speed),
+                    outline-color var(--speed),
+                    box-shadow var(--speed);
+
+                &:hover {
+                    opacity: 0.75;
+                    color: color-mix(in hsl, var(--neon-c) 60%, var(--color));
+                }
             }
         }
-        #container {
-            width: 100%;
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(var(--icon-md), 1fr));
-            gap: var(--space);
-            .item {
-                width: var(--icon-md);
-                max-width: var(--icon-md);
-                aspect-ratio: 1 / 1;
-                input[type="radio"] {
-                    display: none;
-                    &:checked + label {
-                        color: var(--color-accent);
-                    }
-                }
-                label {
-                    display: block;
-                    box-sizing: border-box;
-                    cursor: pointer;
-                    &:hover {
-                        color: var(--color-accent);
-                    }
-                }
-            }
-        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        #container { scroll-behavior: auto; }
+        #container .item label { transition: none; }
     }
 `
 

--- a/src/UI/components/identicons/template.js
+++ b/src/UI/components/identicons/template.js
@@ -1,17 +1,9 @@
 import "/UI/components/identicon/index.js"
-import "/UI/components/icon/index.js"
 import styles from "./styles.css.js"
 import { html } from "/core/UI.js"
 
 export const template = html`
     ${styles}
-    <header>
-        <slot></slot>
-        <nav>
-            <ui-icon id="increase" data-icon="plus-lg" />
-            <ui-icon id="decrease" data-icon="dash-lg" />
-        </nav>
-    </header>
     <div id="container"></div>
 `
 

--- a/src/UI/routes/profile/index.js
+++ b/src/UI/routes/profile/index.js
@@ -4,13 +4,13 @@ import { Access } from "/core/Access.js"
 import States from "/core/States.js"
 
 const SOCIAL_PLATFORMS = [
-    { key: "twitch",    label: "Twitch",    url: (u) => `https://twitch.tv/${u}` },
-    { key: "discord",   label: "Discord",   url: null },
-    { key: "reddit",    label: "Reddit",    url: (u) => `https://reddit.com/u/${u}` },
-    { key: "steam",     label: "Steam",     url: (u) => `https://steamcommunity.com/id/${u}` },
-    { key: "youtube",   label: "YouTube",   url: (u) => `https://youtube.com/@${u}` },
+    { key: "twitch", label: "Twitch", url: (u) => `https://twitch.tv/${u}` },
+    { key: "discord", label: "Discord", url: null },
+    { key: "reddit", label: "Reddit", url: (u) => `https://reddit.com/u/${u}` },
+    { key: "steam", label: "Steam", url: (u) => `https://steamcommunity.com/id/${u}` },
+    { key: "youtube", label: "YouTube", url: (u) => `https://youtube.com/@${u}` },
     { key: "instagram", label: "Instagram", url: (u) => `https://instagram.com/${u}` },
-    { key: "x",         label: "X",         url: (u) => `https://x.com/${u}` },
+    { key: "x", label: "X", url: (u) => `https://x.com/${u}` }
 ]
 
 export class PROFILE extends HTMLElement {
@@ -21,6 +21,7 @@ export class PROFILE extends HTMLElement {
         this.states = new States({ name: "", bio: "", links: {}, following: [], editing: false, editingBio: false, editingLinks: false })
         this.subscriptions = []
         this._followingSubs = []
+        this._followingScope = null
         this._enterEditMode = this._enterEditMode.bind(this)
         this._exitEditMode = this._exitEditMode.bind(this)
         this._onKeydown = this._onKeydown.bind(this)
@@ -58,21 +59,40 @@ export class PROFILE extends HTMLElement {
         this.subscriptions.push(() => $form.removeEventListener("submit", this._onFollowSubmit))
 
         // Wire bio edit controls
-        const $bioEdit   = $("#profile-bio-edit")
-        const $bioSave   = $("#profile-bio-save")
+        const $bioEdit = $("#profile-bio-edit")
+        const $bioSave = $("#profile-bio-save")
         const $bioCancel = $("#profile-bio-cancel")
+        const $bioInput = $("#profile-bio-input")
+        const $bioCount = $("#profile-bio-count")
+        const updateBioCount = () => { $bioCount.textContent = 360 - $bioInput.value.length }
         $bioEdit.addEventListener("click", this._enterBioEditMode)
         $bioSave.addEventListener("click", () => this._exitBioEditMode(true))
         $bioCancel.addEventListener("click", () => this._exitBioEditMode(false))
+        $bioInput.addEventListener("input", updateBioCount)
         this.subscriptions.push(
             () => $bioEdit.removeEventListener("click", this._enterBioEditMode),
             () => $bioSave.removeEventListener("click", () => this._exitBioEditMode(true)),
-            () => $bioCancel.removeEventListener("click", () => this._exitBioEditMode(false))
+            () => $bioCancel.removeEventListener("click", () => this._exitBioEditMode(false)),
+            () => $bioInput.removeEventListener("input", updateBioCount)
         )
 
+        // Wire avatar edit button
+        const $avatarEdit = $("#profile-avatar-edit")
+        const $avatarPicker = $("#profile-avatar-picker")
+        const togglePicker = () => {
+            const opening = !$avatarPicker.classList.contains("is-open")
+            $avatarPicker.classList.toggle("is-open")
+            if (opening) {
+                $avatarPicker.classList.add("is-loading")
+                setTimeout(() => $avatarPicker.classList.remove("is-loading"), 1200)
+            }
+        }
+        $avatarEdit.addEventListener("click", togglePicker)
+        this.subscriptions.push(() => $avatarEdit.removeEventListener("click", togglePicker))
+
         // Wire links edit controls
-        const $linksEdit   = $("#profile-links-edit")
-        const $linksSave   = $("#profile-links-save")
+        const $linksEdit = $("#profile-links-edit")
+        const $linksSave = $("#profile-links-save")
         const $linksCancel = $("#profile-links-cancel")
         $linksEdit.addEventListener("click", this._enterLinksEditMode)
         $linksSave.addEventListener("click", () => this._exitLinksEditMode(true))
@@ -93,14 +113,17 @@ export class PROFILE extends HTMLElement {
                     await this._loadBio()
                     await this._loadLinks()
                     this._loadFollowing()
-                    this._renderFollowing()
-                    this._renderStats()
                 } else {
                     this._exitEditMode(false)
                     this._exitBioEditMode(false)
                     this._exitLinksEditMode(false)
                     $("#profile-name").textContent = ""
                     $("#profile-bio").textContent = ""
+                    this._followingScope?.off?.()
+                    this._followingScope = null
+                    this.states.set({ following: [] })
+                    this._renderFollowing()
+                    this._renderStats()
                 }
             }),
             Access.on("avatar", async () => {
@@ -117,14 +140,13 @@ export class PROFILE extends HTMLElement {
             this._loadBio()
             this._loadLinks()
             this._loadFollowing()
-            this._renderFollowing()
-            this._renderStats()
         }
     }
 
     disconnectedCallback() {
         this.subscriptions.forEach((off) => off())
         this._followingSubs.forEach((off) => off())
+        this._followingScope?.off?.()
     }
 
     _applyAuthState(authenticated) {
@@ -135,6 +157,8 @@ export class PROFILE extends HTMLElement {
         const authControls = $("#profile-auth-controls")
         const bioRow = $("#profile-bio-row")
         const statsRow = $("#profile-stats-row")
+        const avatarEdit = $("#profile-avatar-edit")
+        const avatarPicker = $("#profile-avatar-picker")
 
         if (gate) gate.style.display = authenticated ? "none" : "flex"
         if (sections) sections.style.display = authenticated ? "flex" : "none"
@@ -142,6 +166,8 @@ export class PROFILE extends HTMLElement {
         if (authControls) authControls.style.display = authenticated ? "flex" : "none"
         if (bioRow) bioRow.style.display = authenticated ? "flex" : "none"
         if (statsRow) statsRow.style.display = authenticated ? "flex" : "none"
+        if (avatarEdit) avatarEdit.style.display = authenticated ? "flex" : "none"
+        if (avatarPicker && !authenticated) avatarPicker.classList.remove("is-open")
     }
 
     _hashCode(str) {
@@ -193,7 +219,10 @@ export class PROFILE extends HTMLElement {
         value = value.trim()
         const pair = Access.get("pair")
         if (!pair || !value) return
-        globalThis.gun.get(`~${pair.pub}`).get("name").put(value, null, { opt: { authenticator: pair } })
+        globalThis.gun
+            .get(`~${pair.pub}`)
+            .get("name")
+            .put(value, null, { opt: { authenticator: pair } })
         this.states.set({ name: value })
         const $name = this.shadowRoot.querySelector("#profile-name")
         if ($name) $name.textContent = value
@@ -250,7 +279,10 @@ export class PROFILE extends HTMLElement {
         value = value.trim().slice(0, 360)
         const pair = Access.get("pair")
         if (!pair) return
-        globalThis.gun.get(`~${pair.pub}`).get("bio").put(value, null, { opt: { authenticator: pair } })
+        globalThis.gun
+            .get(`~${pair.pub}`)
+            .get("bio")
+            .put(value, null, { opt: { authenticator: pair } })
         this.states.set({ bio: value })
         const $bio = this.shadowRoot.querySelector("#profile-bio")
         if ($bio) $bio.textContent = value
@@ -258,10 +290,12 @@ export class PROFILE extends HTMLElement {
 
     _enterBioEditMode() {
         const $ = (id) => this.shadowRoot.querySelector(id)
+        const bio = this.states.get("bio")
         $("#profile-bio").style.display = "none"
         $("#profile-bio-edit").style.display = "none"
-        $("#profile-bio-input").value = this.states.get("bio")
-        $("#profile-bio-input").style.display = "block"
+        $("#profile-bio-input").value = bio
+        $("#profile-bio-count").textContent = 360 - bio.length
+        $("#profile-bio-edit-wrap").style.display = "flex"
         $("#profile-bio-save").style.display = "inline-flex"
         $("#profile-bio-cancel").style.display = "inline-flex"
         $("#profile-bio-input").focus()
@@ -271,7 +305,7 @@ export class PROFILE extends HTMLElement {
     _exitBioEditMode(save) {
         const $ = (id) => this.shadowRoot.querySelector(id)
         if (save) this._saveBio($("#profile-bio-input").value)
-        $("#profile-bio-input").style.display = "none"
+        $("#profile-bio-edit-wrap").style.display = "none"
         $("#profile-bio-save").style.display = "none"
         $("#profile-bio-cancel").style.display = "none"
         $("#profile-bio").style.display = ""
@@ -280,8 +314,14 @@ export class PROFILE extends HTMLElement {
     }
 
     _onKeydown(e) {
-        if (e.key === "Enter") { e.preventDefault(); this._exitEditMode(true) }
-        if (e.key === "Escape") { e.preventDefault(); this._exitEditMode(false) }
+        if (e.key === "Enter") {
+            e.preventDefault()
+            this._exitEditMode(true)
+        }
+        if (e.key === "Escape") {
+            e.preventDefault()
+            this._exitEditMode(false)
+        }
     }
 
     _onFollowSubmit(e) {
@@ -298,7 +338,11 @@ export class PROFILE extends HTMLElement {
         const raw = await globalThis.gun.get(`~${pair.pub}`).get("links")
         let links = {}
         if (typeof raw === "string")
-            try { links = JSON.parse(raw) } catch { links = {} }
+            try {
+                links = JSON.parse(raw)
+            } catch {
+                links = {}
+            }
         const allowed = SOCIAL_PLATFORMS.map((p) => p.key)
         links = Object.fromEntries(Object.entries(links).filter(([k]) => allowed.includes(k)))
         this.states.set({ links })
@@ -311,10 +355,13 @@ export class PROFILE extends HTMLElement {
         const allowed = SOCIAL_PLATFORMS.map((p) => p.key)
         const clean = Object.fromEntries(
             Object.entries(obj)
-                .filter(([k, v]) => allowed.includes(k) && typeof v === "string" && v.trim())
+                .filter(([k, v]) => allowed.includes(k) && typeof v === "string" && v.trim() && /^[a-zA-Z0-9._-]{1,64}$/.test(v.trim()))
                 .map(([k, v]) => [k, v.trim()])
         )
-        globalThis.gun.get(`~${pair.pub}`).get("links").put(JSON.stringify(clean), null, { opt: { authenticator: pair } })
+        globalThis.gun
+            .get(`~${pair.pub}`)
+            .get("links")
+            .put(JSON.stringify(clean), null, { opt: { authenticator: pair } })
         this.states.set({ links: clean })
         this._renderLinks()
     }
@@ -334,7 +381,9 @@ export class PROFILE extends HTMLElement {
         if (save) {
             const inputs = this.shadowRoot.querySelectorAll("#profile-links-edit-form input[data-platform]")
             const obj = {}
-            inputs.forEach(($i) => { if ($i.value.trim()) obj[$i.dataset.platform] = $i.value.trim() })
+            inputs.forEach(($i) => {
+                if ($i.value.trim()) obj[$i.dataset.platform] = $i.value.trim()
+            })
             this._saveLinks(obj)
         }
         $("#profile-links-display").style.display = ""
@@ -348,18 +397,13 @@ export class PROFILE extends HTMLElement {
         const container = this.shadowRoot.querySelector("#profile-links-edit-form")
         if (!container) return
         const current = this.states.get("links") || {}
-        const items = SOCIAL_PLATFORMS.map(({ key, label }) =>
-            html`<div class="profile-links__field">
-                <label class="profile-links__label">${label}</label>
-                <input
-                    class="profile-links__input"
-                    type="text"
-                    data-platform="${key}"
-                    value="${current[key] || ""}"
-                    placeholder="Username"
-                    autocomplete="off"
-                />
-            </div>`
+        const items = SOCIAL_PLATFORMS.map(
+            ({ key, label }) => html`
+                <div class="profile-links__field">
+                    <label class="profile-links__label">${label}</label>
+                    <input class="profile-links__input" type="text" data-platform="${key}" value="${current[key] || ""}" placeholder="Username" autocomplete="off" />
+                </div>
+            `
         )
         render(items, container)
     }
@@ -376,12 +420,16 @@ export class PROFILE extends HTMLElement {
         const items = active.map(({ key, label, url }) => {
             const href = url ? url(links[key]) : null
             return href
-                ? html`<a class="profile-link" href="${href}" target="_blank" rel="noopener noreferrer" title="${label}: ${links[key]}" aria-label="${label}">
-                      <ui-icon data-icon="${key}" data-size="md" />
-                  </a>`
-                : html`<span class="profile-link" title="${label}: ${links[key]}" aria-label="${label}">
-                      <ui-icon data-icon="${key}" data-size="md" />
-                  </span>`
+                ? html`
+                      <a class="profile-link" href="${href}" target="_blank" rel="noopener noreferrer" title="${label}: ${links[key]}" aria-label="${label}">
+                          <ui-icon data-icon="${key}" data-size="md" />
+                      </a>
+                  `
+                : html`
+                      <span class="profile-link" title="${label}: ${links[key]}" aria-label="${label}">
+                          <ui-icon data-icon="${key}" data-size="md" />
+                      </span>
+                  `
         })
         render(items, container)
     }
@@ -392,18 +440,27 @@ export class PROFILE extends HTMLElement {
     }
 
     _loadFollowing() {
-        try {
-            const raw = globalThis.localStorage?.getItem("following")
-            this.states.set({ following: raw ? JSON.parse(raw) : [] })
-        } catch {
-            this.states.set({ following: [] })
-        }
-    }
-
-    _saveFollowing() {
-        try {
-            globalThis.localStorage?.setItem("following", JSON.stringify(this.states.get("following") || []))
-        } catch {}
+        const pair = Access.get("pair")
+        if (!pair) return
+        this.states.set({ following: [] })
+        this._followingScope?.off?.()
+        this._followingScope = globalThis.gun.get(`~${pair.pub}`).get("following").map()
+        this._followingScope.on((data, key) => {
+            if (!key || key === "_") return
+            const list = this.states.get("following") || []
+            if (!data) {
+                const filtered = list.filter((f) => f.pub !== key)
+                if (filtered.length === list.length) return
+                this.states.set({ following: filtered })
+                this._renderFollowing()
+                this._renderStats()
+                return
+            }
+            if (list.some((f) => f.pub === key)) return
+            this.states.set({ following: [...list, { pub: key, name: data.name || `${key.slice(0, 8)}…` }] })
+            this._renderFollowing()
+            this._renderStats()
+        })
     }
 
     _addFollow(pub, name) {
@@ -412,15 +469,29 @@ export class PROFILE extends HTMLElement {
         name = name.trim() || `${pub.slice(0, 8)}…`
         const list = this.states.get("following") || []
         if (list.some((f) => f.pub === pub)) return
+        const pair = Access.get("pair")
+        if (!pair) return
+        globalThis.gun
+            .get(`~${pair.pub}`)
+            .get("following")
+            .get(pub)
+            .put({ name, at: Date.now() }, null, { opt: { authenticator: pair } })
         this.states.set({ following: [...list, { pub, name }] })
-        this._saveFollowing()
         this._renderFollowing()
+        this._renderStats()
     }
 
     _removeFollow(pub) {
+        const pair = Access.get("pair")
+        if (!pair) return
+        globalThis.gun
+            .get(`~${pair.pub}`)
+            .get("following")
+            .get(pub)
+            .put(null, null, { opt: { authenticator: pair } })
         this.states.set({ following: (this.states.get("following") || []).filter((f) => f.pub !== pub) })
-        this._saveFollowing()
         this._renderFollowing()
+        this._renderStats()
     }
 
     _renderFollowing() {
@@ -436,16 +507,22 @@ export class PROFILE extends HTMLElement {
             return
         }
 
-        const items = list.map(({ pub, name }) =>
-            html`<div class="profile-following__item">
-                <ui-identicon data-seed="${pub}" data-size="5" />
-                <span class="profile-following__item-name">${name}</span>
-                <button class="profile-following__unfollow" ${({ element }) => {
-                    const unfollow = () => this._removeFollow(pub)
-                    element.addEventListener("click", unfollow)
-                    this._followingSubs.push(() => element.removeEventListener("click", unfollow))
-                }}>Unfollow</button>
-            </div>`
+        const items = list.map(
+            ({ pub, name }) => html`
+                <div class="profile-following__item">
+                    <ui-identicon data-seed="${pub}" data-size="5" />
+                    <span class="profile-following__item-name">${name}</span>
+                    <button
+                        class="profile-following__unfollow"
+                        ${({ element }) => {
+                            const unfollow = () => this._removeFollow(pub)
+                            element.addEventListener("click", unfollow)
+                            this._followingSubs.push(() => element.removeEventListener("click", unfollow))
+                        }}>
+                        Unfollow
+                    </button>
+                </div>
+            `
         )
 
         render(items, container)

--- a/src/UI/routes/profile/styles.css.js
+++ b/src/UI/routes/profile/styles.css.js
@@ -8,6 +8,7 @@ export const styles = css`
 
         /* ── Hero ── */
         .profile-hero {
+            --page-pad: max(var(--space-2), calc((100vw - var(--max-width, 80rem)) / 2));
             position: relative;
             overflow: visible;
             box-sizing: border-box;
@@ -20,7 +21,7 @@ export const styles = css`
                that the game-hero has but the profile hero does not. */
             padding-top: calc(var(--space-4) + var(--hero-pad-top));
             padding-bottom: calc(var(--space-6) + clamp(5rem, 10vw, 8rem));
-            padding-inline: max(var(--space-2), calc((100vw - var(--max-width, 80rem)) / 2));
+            padding-inline: var(--page-pad);
         }
 
         .profile-hero__gradient {
@@ -104,7 +105,7 @@ export const styles = css`
         .profile-avatar {
             position: absolute;
             bottom: 0;
-            left: max(var(--space-2), calc((100vw - var(--max-width, 80rem)) / 2));
+            left: var(--page-pad);
             transform: translateY(50%);
             z-index: 1;
 
@@ -118,6 +119,85 @@ export const styles = css`
                 box-shadow: var(--glow-g);
             }
         }
+
+        .profile-avatar__edit {
+            display: none;
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            align-items: center;
+            justify-content: center;
+            background: color-mix(in hsl, var(--background) 55%, transparent);
+            border: none;
+            cursor: pointer;
+            color: var(--neon-c);
+            opacity: 0;
+            transition: opacity var(--speed);
+
+            &:hover { opacity: 1; }
+            &:active { opacity: 0.7; }
+        }
+
+        #profile-avatar-wrap:hover .profile-avatar__edit,
+        #profile-avatar-wrap:focus-within .profile-avatar__edit {
+            opacity: 0.85;
+        }
+
+        /* ── Avatar picker — sits beside the avatar, same vertical overflow ── */
+        .profile-avatar-picker {
+            /* items = 75% of picker height → selected at scale(1.2) reaches 90%, leaving
+               5% breathing room each side at every breakpoint. No vertical padding needed. */
+            --icon-lg: calc(var(--avatar-size) * 0.75);
+            --identicons-pad-v: 0px;
+            display: none;
+            position: absolute;
+            bottom: 0;
+            /* start right after the avatar */
+            left: calc(var(--page-pad) + var(--avatar-size) + var(--space-3));
+            right: var(--page-pad);
+            height: var(--avatar-size);
+            transform: translateY(50%);
+            z-index: 1;
+            align-items: center;
+            overflow: hidden;
+            border: var(--border-width) solid color-mix(in hsl, var(--neon-c) 25%, transparent);
+            box-shadow: var(--glow-c);
+            background: color-mix(in hsl, var(--background) 88%, transparent);
+            backdrop-filter: blur(var(--blur-md));
+
+            &.is-open { display: flex; }
+
+            ui-avatars {
+                flex: 1;
+                min-width: 0;
+                align-self: stretch;
+            }
+        }
+
+        .profile-avatar-picker__loader {
+            display: none;
+            position: absolute;
+            inset: 0;
+            align-items: center;
+            justify-content: center;
+            background: color-mix(in hsl, var(--background) 88%, transparent);
+            z-index: 1;
+
+            &::after {
+                content: "";
+                width: 1.25rem;
+                height: 1.25rem;
+                border-radius: 50%;
+                border: 2px solid transparent;
+                border-top-color: var(--neon-c);
+                border-right-color: color-mix(in hsl, var(--neon-c) 35%, transparent);
+                box-shadow: var(--glow-c);
+                animation: picker-spin 0.7s linear infinite;
+            }
+        }
+
+        .is-loading .profile-avatar-picker__loader { display: flex; }
 
         /* ── Body ── */
         .profile-body {
@@ -299,9 +379,29 @@ export const styles = css`
             }
         }
 
-        .profile-bio-input {
+        .profile-bio:empty::before {
+            content: "Write something about yourself…";
+            opacity: 0.3;
+            font-style: italic;
+        }
+
+        .profile-bio-edit-wrap {
             display: none;
             flex: 1;
+            flex-direction: column;
+            gap: var(--space-1);
+        }
+
+        .profile-bio-count {
+            font-family: var(--content-font);
+            font-size: var(--text-xs);
+            color: var(--color);
+            opacity: 0.35;
+            text-align: right;
+            letter-spacing: 0.04em;
+        }
+
+        .profile-bio-input {
             font-family: var(--content-font);
             font-size: var(--text-sm);
             color: var(--color);
@@ -345,18 +445,12 @@ export const styles = css`
 
         .profile-bio-save {
             color: var(--neon-g);
-            &:hover {
-                border-color: color-mix(in hsl, var(--neon-g) 50%, transparent);
-                box-shadow: var(--glow-g);
-            }
+            &:hover { opacity: 0.7; }
         }
 
         .profile-bio-cancel {
             color: var(--neon-m);
-            &:hover {
-                border-color: color-mix(in hsl, var(--neon-m) 50%, transparent);
-                box-shadow: var(--glow-m);
-            }
+            &:hover { opacity: 0.7; }
         }
 
         /* ── Stats row ── */
@@ -748,6 +842,10 @@ export const styles = css`
             /* Small phones — sparse grid to avoid clutter */
             .profile-hero__gradient { --grid-v: 10%; }
         }
+    }
+
+    @keyframes picker-spin {
+        to { transform: rotate(360deg); }
     }
 `
 

--- a/src/UI/routes/profile/template.js
+++ b/src/UI/routes/profile/template.js
@@ -13,8 +13,15 @@ export const template = html`
     <layout-main>
         <header class="profile-hero">
             <div class="profile-hero__gradient"></div>
-            <div class="profile-avatar">
+            <div class="profile-avatar" id="profile-avatar-wrap">
                 <ui-identicon id="profile-identicon" data-size="11" />
+                <button class="profile-avatar__edit" id="profile-avatar-edit" aria-label="Change avatar">
+                    <ui-icon data-icon="pen" data-size="md" />
+                </button>
+            </div>
+            <div class="profile-avatar-picker" id="profile-avatar-picker">
+                <span class="profile-avatar-picker__loader" aria-hidden="true"></span>
+                <ui-avatars />
             </div>
         </header>
 
@@ -44,7 +51,10 @@ export const template = html`
                 <button class="profile-bio-edit" id="profile-bio-edit" aria-label="Edit bio">
                     <ui-icon data-icon="pen" data-size="md" />
                 </button>
-                <textarea class="profile-bio-input" id="profile-bio-input" maxlength="360" rows="3" placeholder="Write something about yourself…"></textarea>
+                <div class="profile-bio-edit-wrap" id="profile-bio-edit-wrap">
+                    <textarea class="profile-bio-input" id="profile-bio-input" maxlength="360" rows="3" placeholder="Write something about yourself…"></textarea>
+                    <span class="profile-bio-count" id="profile-bio-count">360</span>
+                </div>
                 <button class="profile-bio-save" id="profile-bio-save" aria-label="Save bio">
                     <ui-icon data-icon="check-lg" data-size="md" />
                 </button>
@@ -60,22 +70,12 @@ export const template = html`
                 </span>
             </div>
 
-            <div class="profile-actions" id="profile-actions" hidden>
-                <button class="profile-action-btn profile-action-btn--follow" disabled>Follow</button>
-                <button class="profile-action-btn profile-action-btn--message" disabled>Message</button>
-            </div>
-
             <div class="profile-gate" id="profile-gate">
                 <p>Sign in to view your profile.</p>
                 <ui-authorize />
             </div>
 
             <div id="profile-sections">
-                <section class="profile-section">
-                    <h2 class="profile-section__heading">Avatar</h2>
-                    <ui-avatars />
-                </section>
-
                 <section class="profile-section" id="profile-links-section">
                     <h2 class="profile-section__heading">Links</h2>
                     <div class="profile-links" id="profile-links-display"></div>
@@ -99,7 +99,7 @@ export const template = html`
                     <h2 class="profile-section__heading">Following</h2>
                     <div class="profile-following" id="profile-following-list"></div>
                     <form class="profile-following__add" id="profile-follow-form" autocomplete="off">
-                        <input type="text" id="profile-follow-pub" placeholder="Public key" required />
+                        <input type="text" id="profile-follow-pub" placeholder="Paste 88-char public key" required />
                         <input type="text" id="profile-follow-name" placeholder="Display name" />
                         <button type="submit" class="profile-following__add-btn">Follow</button>
                     </form>


### PR DESCRIPTION
## Summary

Wraps up the `/profile` route's MVP functionality: social links now validate usernames before saving, the following list migrates from localStorage to Gun for cross-device persistence, a new inline scroll-snap avatar picker replaces the separate Avatar section, and bio editing gains an empty-state placeholder and live character countdown.

---

## Identity & Security

Social link usernames are now validated against `/^[a-zA-Z0-9._-]{1,64}$/` before being written to Gun. Invalid entries are silently dropped at save time — consistent with how unknown platform keys are already handled. This closes a path where a crafted username could produce a malformed `href` in the rendered link list.

---

## Social Graph

The following list moves from `localStorage` (device-local, volatile) to the user's own Gun node at `~{pub}/following`. `_loadFollowing` subscribes via `.map().on()`, which fires on initial load and on any subsequent Gun sync, so a follow/unfollow on one device propagates automatically to others sharing the same passkey. Deletions use `put(null)` tombstones — the same pattern as `ui-addresses`. The `_saveFollowing` helper is removed entirely; `disconnectedCallback` and the logout branch both call `_followingScope.off()` to stop the subscription cleanly.

---

## Avatar Picker

The standalone Avatar section is replaced by an inline picker that slides open next to the profile identicon when the user taps the pen icon overlay. The picker is positioned inside `<header class="profile-hero">` so it shares the same reference frame as the avatar — `position: absolute; bottom: 0; transform: translateY(50%)` lets it straddle the hero/body boundary at all breakpoints. Identicon sizing is controlled via CSS custom properties (`--icon-lg: calc(var(--avatar-size) * 0.75)`, `--identicons-pad-v: 0px`) that cascade through Shadow DOM boundaries, so items fill the panel at every viewport without hardcoded values. The `+/-` load-more buttons are replaced by scroll-end detection: when the user scrolls within 50% of the container's visible width from the end, a `increase` event fires with a 600ms cooldown. A CSS loading spinner (`picker-spin` keyframes) covers the picker while the first batch of identicons renders.

---

## Bio Editing

`.profile-bio:empty::before` provides an always-visible placeholder so the section doesn't appear blank before a user adds a bio. The edit form now wraps the textarea in `#profile-bio-edit-wrap` and adds a `#profile-bio-count` span that counts down from 360 as the user types. Hover styles on the save/cancel buttons are simplified to `opacity: 0.7` — the box glow from before was visually heavy against the bio field focus ring.

---

## Test Plan

- [ ] Sign in → profile loads name, avatar, bio, social links with no console errors
- [ ] Social links: save a link with username `../../evil` → entry is dropped, no `href` written
- [ ] Following: add a pub key → survives page reload (not localStorage)
- [ ] Following: add on device A → reload on device B (same passkey) → entry appears
- [ ] Following: unfollow → entry disappears and does not return on reload
- [ ] Avatar: tap pen icon → picker opens beside identicon, straddles hero bottom edge
- [ ] Avatar: scroll to end of identicon strip → next batch loads without a visible button
- [ ] Avatar: select identicon → profile identicon updates, picker closes
- [ ] Bio: empty bio → placeholder text visible; enter edit mode → textarea placeholder visible
- [ ] Bio: type in textarea → counter counts down from 360
- [ ] Sign out → avatar picker closes, following list clears, pen icon hides
- [ ] DevTools shadow root → no `profile-actions` div present
