### PR TITLE
refactor(UI): introduce BaseElement/BaseRoute lifecycle abstraction

### DIFF
--- a/docs/todos/huy/2026Apr07.md
+++ b/docs/todos/huy/2026Apr07.md
@@ -65,3 +65,20 @@ Add subtle hover effects to pool rows to improve discoverability and user engage
 - Use existing `--speed` CSS custom property
 - Stagger effects for visual polish
 - Respect `prefers-reduced-motion` media query
+
+---
+
+## 3. `game/[game]` Route Filter Blur — Investigation Note
+
+The filter blur issue appears in `src/UI/routes/game/[game]/index.js`, which still uses the legacy `HTMLElement` lifecycle and was not refactored in the current batch. The `ui-game-item` component is also separate from the filter logic, so this looks unrelated to the BaseElement/BaseRoute refactor.
+
+**Observation:**
+
+- The route adds `is-loading-all` opacity behavior when filters trigger additional page loads
+- New items are created and inserted via `grid.replaceChildren(...elements)`
+- There is no BaseElement/BaseRoute involvement in this route
+
+**Action:**
+
+- Do not change refactor code for this bug yet
+- Track this issue separately and investigate the game route filter/load flow next

--- a/src/UI/BaseElement.js
+++ b/src/UI/BaseElement.js
@@ -1,0 +1,79 @@
+/**
+ * BaseElement - Shared base class for all custom elements
+ * Centralizes lifecycle, subscription management, and event listener cleanup
+ */
+export class BaseElement extends HTMLElement {
+    constructor() {
+        super()
+        this.subscriptions = []
+    }
+
+    /**
+     * Register cleanup functions to run on disconnectedCallback
+     * @param {...Function} offFns - Functions to call on disconnect (e.g., event listener removers, unsubscribers)
+     */
+    subscribe(...offFns) {
+        this.subscriptions.push(...offFns.filter(Boolean))
+    }
+
+    /**
+     * Attach event listener with automatic cleanup on disconnect
+     * @param {EventTarget} target - Element or object that emits events
+     * @param {string} event - Event name
+     * @param {Function} handler - Event handler
+     * @param {Object} options - addEventListener options (capture, once, passive, etc.)
+     * @returns {Function} The unsubscribe function (also auto-registered)
+     */
+    listen(target, event, handler, options) {
+        if (!target) return
+        target.addEventListener(event, handler, options)
+        const off = () => target.removeEventListener(event, handler, options)
+        this.subscriptions.push(off)
+        return off
+    }
+
+    /**
+     * Subscribe to Context or States updates with automatic cleanup
+     * @param {Object} observable - Context or States instance
+     * @param {string|Array} key - Key(s) to watch
+     * @param {Function} callback - Callback when value changes
+     * @param {boolean} immediate - Trigger callback immediately
+     * @returns {Function} The unsubscribe function (also auto-registered)
+     */
+    watch(observable, key, callback, immediate = false) {
+        if (!observable || !observable.on) return
+        const off = observable.on(key, callback, immediate)
+        this.subscriptions.push(off)
+        return off
+    }
+
+    /**
+     * Called when element connects to DOM (override in subclasses)
+     * Guaranteed to run after constructor
+     */
+    onConnect() {}
+
+    /**
+     * Called when element disconnects from DOM (override in subclasses)
+     * Runs before auto-cleanup of subscriptions
+     */
+    onDisconnect() {}
+
+    /**
+     * Standard lifecycle hook - calls onConnect then auto-cleanup on disconnect
+     */
+    connectedCallback() {
+        this.onConnect()
+    }
+
+    /**
+     * Standard lifecycle hook - runs onDisconnect then clears all subscriptions
+     */
+    disconnectedCallback() {
+        this.onDisconnect()
+        this.subscriptions.forEach(off => off())
+        this.subscriptions.length = 0
+    }
+}
+
+export default BaseElement

--- a/src/UI/BaseRoute.js
+++ b/src/UI/BaseRoute.js
@@ -1,0 +1,39 @@
+/**
+ * BaseRoute - Specialized base class for route components
+ * Extends BaseElement with shadow DOM setup and template rendering
+ */
+import { render } from "/core/UI.js"
+import BaseElement from "./BaseElement.js"
+
+export class BaseRoute extends BaseElement {
+    constructor(template) {
+        super()
+        this.template = template
+        this.attachShadow({ mode: "open" })
+        if (template) render(template, this.shadowRoot)
+    }
+
+    /**
+     * Query selector within shadow DOM (convenience method)
+     */
+    query(selector) {
+        return this.shadowRoot.querySelector(selector)
+    }
+
+    /**
+     * Query all within shadow DOM (convenience method)
+     */
+    queryAll(selector) {
+        return this.shadowRoot.querySelectorAll(selector)
+    }
+
+    /**
+     * Re-render template into shadow DOM
+     * Useful for routes that need to update their template after fetch
+     */
+    renderTemplate(template = this.template) {
+        if (template) render(template, this.shadowRoot)
+    }
+}
+
+export default BaseRoute

--- a/src/UI/components/a/index.js
+++ b/src/UI/components/a/index.js
@@ -6,6 +6,7 @@ export class A extends HTMLAnchorElement {
         super()
         this.click = this.click.bind(this)
         this.render = this.render.bind(this)
+        this.subscriptions = []
     }
 
     static get observedAttributes() {
@@ -19,12 +20,12 @@ export class A extends HTMLAnchorElement {
 
     connectedCallback() {
         this.addEventListener("click", this.click)
-        this.subscription = Context.on("locale", this.render)
+        this.subscriptions.push(Context.on("locale", this.render))
     }
 
     disconnectedCallback() {
         this.removeEventListener("click", this.click)
-        this.subscription.off()
+        this.subscriptions.forEach(off => off())
     }
 
     click(e) {

--- a/src/UI/components/access/index.js
+++ b/src/UI/components/access/index.js
@@ -3,14 +3,14 @@ import { Context } from "/core/Context.js"
 import { Access } from "/core/Access.js"
 import template from "./template.js"
 import { render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class ACCESS extends HTMLElement {
+export class ACCESS extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.next = this.next.bind(this)
         this.checkpoint = this.checkpoint.bind(this)
         this.show = this.show.bind(this)
@@ -23,7 +23,7 @@ export class ACCESS extends HTMLElement {
         this.onmodalclose = this.onmodalclose.bind(this)
     }
 
-    connectedCallback() {
+    onConnect() {
         // Assign to Elements only after component is fully connected and modal is initialized
         Elements.Access = this
         this.modal = this.shadowRoot.querySelector("ui-modal")
@@ -31,25 +31,19 @@ export class ACCESS extends HTMLElement {
         this.form = this.shadowRoot.querySelector("#signup-form")
         this.auth = this.shadowRoot.querySelector("#auth")
         this.$back = this.shadowRoot.querySelector("#back")
-        this.$back.addEventListener("click", this.unauthenticated)
-        this.shadowRoot.querySelector("#signup").addEventListener("click", this.signupScreen)
-        this.shadowRoot.querySelector("#confirm").addEventListener("click", this.signup)
-        this.shadowRoot.querySelector("#signin").addEventListener("click", this.signinScreen)
-        this.$dialog?.addEventListener("close", this.onmodalclose)
-        this.subscriptions.push(
-            () => this.$back.removeEventListener("click", this.unauthenticated),
-            () => this.shadowRoot.querySelector("#signup").removeEventListener("click", this.signupScreen),
-            () => this.shadowRoot.querySelector("#confirm").removeEventListener("click", this.signup),
-            () => this.shadowRoot.querySelector("#signin").removeEventListener("click", this.signinScreen),
-            () => this.$dialog?.removeEventListener("close", this.onmodalclose),
+        this.listen(this.$back, "click", this.unauthenticated)
+        this.listen(this.shadowRoot.querySelector("#signup"), "click", this.signupScreen)
+        this.listen(this.shadowRoot.querySelector("#confirm"), "click", this.signup)
+        this.listen(this.shadowRoot.querySelector("#signin"), "click", this.signinScreen)
+        this.listen(this.$dialog, "close", this.onmodalclose)
+        this.subscribe(
             this.auth?.events?.on?.("done", this.ondone)
         )
-        this.form.querySelectorAll("input[type='text']").forEach((input) => this.subscriptions.push(Context.on(["dictionary", input.name], [input, "placeholder"])))
+        this.form.querySelectorAll("input[type='text']").forEach((input) => this.subscribe(Context.on(["dictionary", input.name], [input, "placeholder"])))
     }
 
-    disconnectedCallback() {
+    onDisconnect() {
         if (Elements.Access === this) Elements.Access = null
-        this.subscriptions.forEach((off) => off())
     }
 
     onmodalclose() {

--- a/src/UI/components/addresses/index.js
+++ b/src/UI/components/addresses/index.js
@@ -53,6 +53,7 @@ export class ADDRESSES extends BaseElement {
                         addresses[key] = address
                         this.states.set({ addresses })
                     })
+                    this.subscribe(() => this.scope?.off?.())
                 }
             })
         )

--- a/src/UI/components/addresses/index.js
+++ b/src/UI/components/addresses/index.js
@@ -5,10 +5,11 @@ import { notify, randomKey } from "/core/Utils.js"
 import { Access } from "/core/Access.js"
 import { Elements } from "/core/Stores.js"
 import States from "/core/States.js"
+import BaseElement from "/UI/BaseElement.js"
 import "/UI/components/icon/index.js"
 import logic from "./logic.js"
 
-export class ADDRESSES extends HTMLElement {
+export class ADDRESSES extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
@@ -23,50 +24,41 @@ export class ADDRESSES extends HTMLElement {
         this.confirm = this.confirm.bind(this)
         this.cancel = this.cancel.bind(this)
         this.render = this.render.bind(this)
-        this.subscriptions = []
     }
 
-    async connectedCallback() {
+    async onConnect() {
         this.countries = await logic.countries()
         this.modal = this.shadowRoot.querySelector("ui-modal#deletion")
         this.form = this.shadowRoot.querySelector("#address-form")
-        this.form.querySelectorAll("input[type='text'], input[type='email'], input[type='tel']").forEach((input) => this.subscriptions.push(Context.on(["dictionary", input.name], [input, "placeholder"])))
-        this.shadowRoot.querySelector("#cancel").addEventListener("click", this.cancel)
-        this.shadowRoot.querySelector("#add").addEventListener("click", this.add)
-        this.shadowRoot.querySelector("#save").addEventListener("click", this.save)
-        this.shadowRoot.querySelector("#close").addEventListener("click", this.close)
-        this.shadowRoot.querySelector("#reset").addEventListener("click", this.reset)
-        this.shadowRoot.querySelector("#confirm").addEventListener("click", this.confirm)
+        this.form.querySelectorAll("input[type='text'], input[type='email'], input[type='tel']").forEach((input) => this.subscribe(Context.on(["dictionary", input.name], [input, "placeholder"])))
+        this.listen(this.shadowRoot.querySelector("#cancel"), "click", this.cancel)
+        this.listen(this.shadowRoot.querySelector("#add"), "click", this.add)
+        this.listen(this.shadowRoot.querySelector("#save"), "click", this.save)
+        this.listen(this.shadowRoot.querySelector("#close"), "click", this.close)
+        this.listen(this.shadowRoot.querySelector("#reset"), "click", this.reset)
+        this.listen(this.shadowRoot.querySelector("#confirm"), "click", this.confirm)
         const $delete = () => {
             const id = this.states.get("current")
             if (!id) return
             this.delete(id)
         }
-        this.shadowRoot.querySelector("#delete").addEventListener("click", $delete)
-        this.subscriptions.push(
-            () => this.shadowRoot.querySelector("#cancel").removeEventListener("click", this.cancel),
-            () => this.shadowRoot.querySelector("#add").removeEventListener("click", this.add),
-            () => this.shadowRoot.querySelector("#save").removeEventListener("click", this.save),
-            () => this.shadowRoot.querySelector("#close").removeEventListener("click", this.close),
-            () => this.shadowRoot.querySelector("#reset").removeEventListener("click", this.reset),
-            () => this.shadowRoot.querySelector("#confirm").removeEventListener("click", this.confirm),
-            () => this.shadowRoot.querySelector("#delete").removeEventListener("click", $delete),
-            this.states.on("addresses", this.render)
+        this.listen(this.shadowRoot.querySelector("#delete"), "click", $delete)
+        this.subscribe(
+            this.states.on("addresses", this.render),
+            Access.on("authenticated", () => {
+                if (logic.pair()) {
+                    this.scope?.off?.()
+                    this.scope = logic.watch((key, address) => {
+                        const addresses = { ...this.states.get("addresses") }
+                        addresses[key] = address
+                        this.states.set({ addresses })
+                    })
+                }
+            })
         )
-        this.subscriptions.push(Access.on("authenticated", () => {
-            if (logic.pair()) {
-                this.scope?.off?.()
-                this.scope = logic.watch((key, address) => {
-                    const addresses = { ...this.states.get("addresses") }
-                    addresses[key] = address
-                    this.states.set({ addresses })
-                })
-            }
-        }))
     }
 
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
+    onDisconnect() {
         this?.scope?.off?.()
     }
 

--- a/src/UI/components/authenticate/index.js
+++ b/src/UI/components/authenticate/index.js
@@ -4,15 +4,15 @@ import Events from "/core/Events.js"
 import States from "/core/States.js"
 import { Context } from "/core/Context.js"
 import { notify } from "/core/Utils/browser.js"
+import BaseElement from "/UI/BaseElement.js"
 import Logic from "./logic.js"
 
-export class AUTHENTICATE extends HTMLElement {
+export class AUTHENTICATE extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
         this.events = new Events(this)
-        this.subscriptions = []
         this.logic = new Logic()
         this.states = new States({ method: null })
         this.state = "neutral"
@@ -25,20 +25,16 @@ export class AUTHENTICATE extends HTMLElement {
         this.wave = this.wave.bind(this)
     }
 
-    connectedCallback() {
+    onConnect() {
         this.$wave = this.shadowRoot.querySelector("ui-wave")
         this.$requestbtn = this.shadowRoot.querySelector("#request-btn")
         this.$stopbtn = this.shadowRoot.querySelector("#stop-btn")
         this.$epub = this.shadowRoot.querySelector("#epub")
-        this.$requestbtn.addEventListener("click", this.onrequestbtn)
-        this.$stopbtn.addEventListener("click", this.onstopbtn)
-        this.shadowRoot.querySelector("#passkey").addEventListener("click", this.passkey)
-        this.shadowRoot.querySelector("#wave").addEventListener("click", this.wave)
-        this.subscriptions.push(
-            () => this.$requestbtn.removeEventListener("click", this.onrequestbtn),
-            () => this.$stopbtn.removeEventListener("click", this.onstopbtn),
-            () => this.shadowRoot.querySelector("#passkey").removeEventListener("click", this.passkey),
-            () => this.shadowRoot.querySelector("#wave").removeEventListener("click", this.wave),
+        this.listen(this.$requestbtn, "click", this.onrequestbtn)
+        this.listen(this.$stopbtn, "click", this.onstopbtn)
+        this.listen(this.shadowRoot.querySelector("#passkey"), "click", this.passkey)
+        this.listen(this.shadowRoot.querySelector("#wave"), "click", this.wave)
+        this.subscribe(
             this.$wave.events.on("message", this.onwave),
             this.states.on("method", this.render)
         )
@@ -46,8 +42,7 @@ export class AUTHENTICATE extends HTMLElement {
         this.initpair()
     }
 
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
+    onDisconnect() {
         this.stop()
     }
 

--- a/src/UI/components/authorize/index.js
+++ b/src/UI/components/authorize/index.js
@@ -2,14 +2,14 @@ import { Elements } from "/core/Stores.js"
 import { render } from "/core/UI.js"
 import template from "./template.js"
 import States from "/core/States.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class AUTHORIZE extends HTMLElement {
+export class AUTHORIZE extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.states = new States({ state: "listening" })
         this.pending = null
         this.render = this.render.bind(this)
@@ -21,7 +21,7 @@ export class AUTHORIZE extends HTMLElement {
         this.onclose = this.onclose.bind(this)
     }
 
-    connectedCallback() {
+    onConnect() {
         this.$authorize = this.shadowRoot.querySelector("#authorize")
         this.$modal = this.shadowRoot.querySelector("ui-modal")
         this.$wave = this.shadowRoot.querySelector("ui-wave")
@@ -30,24 +30,19 @@ export class AUTHORIZE extends HTMLElement {
         this.$deny = this.shadowRoot.querySelector("#deny")
         this.$stop = this.shadowRoot.querySelector("#stop")
         this.$dialog = this.$modal.shadowRoot?.querySelector("dialog")
-        this.$authorize.addEventListener("click", this.toggle)
-        this.$grant.addEventListener("click", this.grant)
-        this.$deny.addEventListener("click", this.deny)
-        this.$stop.addEventListener("click", this.stop)
-        this.$dialog?.addEventListener("close", this.onclose)
-        this.subscriptions.push(
-            () => this.$deny.removeEventListener("click", this.deny),
-            () => this.$grant.removeEventListener("click", this.grant),
-            () => this.$stop.removeEventListener("click", this.stop),
-            () => this.$dialog?.removeEventListener("close", this.onclose),
+        this.listen(this.$authorize, "click", this.toggle)
+        this.listen(this.$grant, "click", this.grant)
+        this.listen(this.$deny, "click", this.deny)
+        this.listen(this.$stop, "click", this.stop)
+        this.listen(this.$dialog, "close", this.onclose)
+        this.subscribe(
             this.$wave.events.on("message", this.wave),
             this.states.on("state", this.render)
         )
         this.render()
     }
 
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
+    onDisconnect() {
         this.$wave?.stop?.()
     }
 

--- a/src/UI/components/avatars/index.js
+++ b/src/UI/components/avatars/index.js
@@ -2,15 +2,15 @@ import template from "./template.js"
 import { Access } from "/core/Access.js"
 import Events from "/core/Events.js"
 import { render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class AVATARS extends HTMLElement {
+export class AVATARS extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
         this.events = new Events()
-        this.subscriptions = []
         this._previewId = null
         this.step = 5
     }
@@ -31,7 +31,7 @@ export class AVATARS extends HTMLElement {
         return logic.settotal(value)
     }
 
-    connectedCallback() {
+    onConnect() {
         this.$identicons = this.shadowRoot.querySelector("ui-identicons")
 
         const seed = async () => {
@@ -43,15 +43,10 @@ export class AVATARS extends HTMLElement {
         const $accept = this.shadowRoot.querySelector("#avatar-accept")
         const onCancel = () => this.events.emit("cancel")
         const onAccept = () => this.events.emit("accept")
-        $cancel.addEventListener("click", onCancel)
-        $accept.addEventListener("click", onAccept)
+        this.listen($cancel, "click", onCancel)
+        this.listen($accept, "click", onAccept)
 
-        this.subscriptions.push(
-            () => $cancel.removeEventListener("click", onCancel),
-            () => $accept.removeEventListener("click", onAccept)
-        )
-
-        this.subscriptions.push(
+        this.subscribe(
             this.$identicons.events.on("select", ({ detail: { id } }) => {
                 this._previewId = id
                 this.$identicons.id = id

--- a/src/UI/components/button/index.js
+++ b/src/UI/components/button/index.js
@@ -1,14 +1,15 @@
 import template from "./template.js"
 import { render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 
-export class BUTTON extends HTMLElement {
+export class BUTTON extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
     }
 
-    connectedCallback() {
+    onConnect() {
         this.shadowRoot.querySelector("button").classList = this.classList
         let left = this.dataset.left
         let right = this.dataset.right

--- a/src/UI/components/camera/index.js
+++ b/src/UI/components/camera/index.js
@@ -1,8 +1,9 @@
 import { render } from "/core/UI.js"
 import Events from "/core/Events.js"
 import template from "./template.js"
+import BaseElement from "/UI/BaseElement.js"
 
-export class CAMERA extends HTMLElement {
+export class CAMERA extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
@@ -19,7 +20,6 @@ export class CAMERA extends HTMLElement {
         this.switch = this.switch.bind(this)
         this.capture = this.capture.bind(this)
         this.resume = this.resume.bind(this)
-        this.subscriptions = []
     }
 
     static get observedAttributes() {
@@ -36,27 +36,21 @@ export class CAMERA extends HTMLElement {
         if (name === "data-status") this.status.dataset.key = value
     }
 
-    connectedCallback() {
+    onConnect() {
         this.video = this.shadowRoot.querySelector("#video")
         this.$switch = this.shadowRoot.querySelector("#switch")
         this.$capture = this.shadowRoot.querySelector("#capture")
         this.$resume = this.shadowRoot.querySelector("#resume")
         this.status = this.shadowRoot.querySelector("ui-context#status")
-        this.$switch.addEventListener("click", this.switch)
-        this.$capture.addEventListener("click", this.capture)
-        this.$resume.addEventListener("click", this.resume)
-        this.subscriptions.push(
-            () => this.$switch.removeEventListener("click", this.switch),
-            () => this.$capture.removeEventListener("click", this.capture),
-            () => this.$resume.removeEventListener("click", this.resume),
-            this.stop
-        )
+        this.listen(this.$switch, "click", this.switch)
+        this.listen(this.$capture, "click", this.capture)
+        this.listen(this.$resume, "click", this.resume)
+        this.subscribe(this.stop.bind(this))
         if (this.dataset.autostart !== "false") this.start()
     }
 
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
-        this.subscriptions = []
+    onDisconnect() {
+        this.stop()
     }
 
     async list() {

--- a/src/UI/components/cart/index.js
+++ b/src/UI/components/cart/index.js
@@ -1,28 +1,24 @@
 import template from "./template.js"
 import { Context } from "/core/Context.js"
 import { html, render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 import Cart from "/core/Cart.js"
 import logic from "./logic.js"
 
-export class CART extends HTMLElement {
+export class CART extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.render = this.render.bind(this)
     }
 
-    connectedCallback() {
+    onConnect() {
         const button = this.shadowRoot.querySelector("ui-icon")
         this.modal = this.shadowRoot.querySelector("ui-modal")
-        button.addEventListener("click", this.modal.toggleModal)
-        this.subscriptions.push(() => button.removeEventListener("click", this.modal.toggleModal), Cart.states.on("list", this.render), Context.on("locale", this.render))
+        this.listen(button, "click", this.modal.toggleModal.bind(this.modal))
+        this.subscribe(Cart.states.on("list", this.render), Context.on("locale", this.render))
         this.render()
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 
     async render() {

--- a/src/UI/components/cart/index.js
+++ b/src/UI/components/cart/index.js
@@ -18,6 +18,18 @@ export class CART extends BaseElement {
         this.modal = this.shadowRoot.querySelector("ui-modal")
         this.listen(button, "click", this.modal.toggleModal.bind(this.modal))
         this.subscribe(Cart.states.on("list", this.render), Context.on("locale", this.render))
+        this.listen(this.modal, "click", (e) => {
+            const icon = e.composedPath().find(el => el.tagName === "UI-ICON")
+            if (!icon) return
+            const itemDiv = icon.closest?.(".item")
+            if (!itemDiv) return
+            const index = [...itemDiv.parentNode.children].indexOf(itemDiv)
+            const item = Cart.states.get("list")[index]
+            if (!item) return
+            if (icon.dataset.icon === "dash-lg") Cart.decrease(item.key, 1)
+            else if (icon.dataset.icon === "plus-lg") Cart.increase(item.key, 1)
+            else if (icon.dataset.icon === "x-lg") Cart.remove(item.key)
+        })
         this.render()
     }
 
@@ -25,36 +37,15 @@ export class CART extends BaseElement {
         const list = []
         for (const item of Cart.states.get("list")) {
             const $item = await logic.item(item.id, Context.get("locale").code)
-            const increase = () => Cart.increase(item.key, 1)
-            const decrease = () => Cart.decrease(item.key, 1)
-            const remove = () => Cart.remove(item.key)
             list.push(html`
                 <div class="item">
                     <div><a is="ui-a" data-to="/item/${item.id}">${$item.name}</a></div>
                     <div><ui-fiat data-amount="${item.total}" /></div>
                     <div class="actions">
-                        <ui-icon
-                            data-size="sm"
-                            data-icon="dash-lg"
-                            ${({ element }) => {
-                                element.addEventListener("click", decrease)
-                                this.subscriptions.push(() => element.removeEventListener("click", decrease))
-                            }} />
+                        <ui-icon data-size="sm" data-icon="dash-lg" />
                         <span>${item.quantity}</span>
-                        <ui-icon
-                            data-size="sm"
-                            data-icon="plus-lg"
-                            ${({ element }) => {
-                                element.addEventListener("click", increase)
-                                this.subscriptions.push(() => element.removeEventListener("click", increase))
-                            }} />
-                        <ui-icon
-                            data-size="sm"
-                            data-icon="x-lg"
-                            ${({ element }) => {
-                                element.addEventListener("click", remove)
-                                this.subscriptions.push(() => element.removeEventListener("click", remove))
-                            }} />
+                        <ui-icon data-size="sm" data-icon="plus-lg" />
+                        <ui-icon data-size="sm" data-icon="x-lg" />
                     </div>
                 </div>
             `)

--- a/src/UI/components/context/index.js
+++ b/src/UI/components/context/index.js
@@ -1,11 +1,11 @@
 import { Context } from "/core/Context.js"
 import States from "/core/States.js"
+import BaseElement from "/UI/BaseElement.js"
 
-export class CONTEXT extends HTMLElement {
+export class CONTEXT extends BaseElement {
     constructor(props = {}) {
         super()
         this.states = new States({ key: props.key || null })
-        this.subscriptions = []
         this.subscription = null
         this.render = this.render.bind(this)
         this.on = this.on.bind(this)
@@ -23,14 +23,13 @@ export class CONTEXT extends HTMLElement {
         this.states.set({ key: value })
     }
 
-    connectedCallback() {
-        this.subscriptions.push(this.states.on("key", this.render))
+    onConnect() {
+        this.watch(this.states, "key", this.render)
         this.on()
         this.render()
     }
 
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
+    onDisconnect() {
         this.off()
     }
 

--- a/src/UI/components/fiat/index.js
+++ b/src/UI/components/fiat/index.js
@@ -1,12 +1,12 @@
 import { Statics } from "/core/Stores.js"
 import { Context } from "/core/Context.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class FIAT extends HTMLElement {
+export class FIAT extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
-        this.subscriptions = []
         this.render = this.render.bind(this)
     }
 
@@ -18,13 +18,9 @@ export class FIAT extends HTMLElement {
         if (["data-locale", "data-amount", "data-base", "data-quote"].includes(name) && last !== value) this.render()
     }
 
-    connectedCallback() {
-        this.subscriptions.push(Context.on("locale", this.render), Context.on("fiat", this.render))
+    onConnect() {
+        this.subscribe(Context.on("locale", this.render), Context.on("fiat", this.render))
         this.render()
-    }
-
-    disconnected() {
-        this.subscriptions.forEach((off) => off())
     }
 
     async render() {

--- a/src/UI/components/game-item/index.js
+++ b/src/UI/components/game-item/index.js
@@ -1,14 +1,15 @@
 import template from "./template.js"
 import { render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 
-export class GAME_ITEM extends HTMLElement {
+export class GAME_ITEM extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
     }
 
-    connectedCallback() {
+    onConnect() {
         this._populate()
     }
 

--- a/src/UI/components/game-nav/index.js
+++ b/src/UI/components/game-nav/index.js
@@ -3,40 +3,33 @@ import { Context } from "/core/Context.js"
 import States from "/core/States.js"
 import { html, render } from "/core/UI.js"
 import { events } from "/core/Events.js"
+import BaseElement from "/UI/BaseElement.js"
 import "/UI/components/a/index.js"
 import "/UI/components/svg/index.js"
 import logic from "./logic.js"
 
-export class GAME_NAV extends HTMLElement {
+export class GAME_NAV extends BaseElement {
     constructor() {
         super()
         this.states = new States({ open: false, games: [] })
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this._toggle = this._toggle.bind(this)
         this._close = this._close.bind(this)
         this._render = this._render.bind(this)
     }
 
-    async connectedCallback() {
-        this.shadowRoot.querySelector(".game-nav__toggle")?.addEventListener("click", this._toggle)
-        this.shadowRoot.querySelector(".game-nav__close")?.addEventListener("click", this._close)
-        this.shadowRoot.querySelector(".game-nav__backdrop")?.addEventListener("click", this._close)
-        this.subscriptions.push(
+    async onConnect() {
+        this.listen(this.shadowRoot.querySelector(".game-nav__toggle"), "click", this._toggle)
+        this.listen(this.shadowRoot.querySelector(".game-nav__close"), "click", this._close)
+        this.listen(this.shadowRoot.querySelector(".game-nav__backdrop"), "click", this._close)
+        this.subscribe(
             Context.on("locale", this._render),
             Context.on("params", this._render),
-            events.on("game-nav:open", this._toggle),
-            () => this.shadowRoot.querySelector(".game-nav__toggle")?.removeEventListener("click", this._toggle),
-            () => this.shadowRoot.querySelector(".game-nav__close")?.removeEventListener("click", this._close),
-            () => this.shadowRoot.querySelector(".game-nav__backdrop")?.removeEventListener("click", this._close)
+            events.on("game-nav:open", this._toggle)
         )
         await this._loadGames()
         this._render()
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 
     async _loadGames() {

--- a/src/UI/components/geo/index.js
+++ b/src/UI/components/geo/index.js
@@ -1,10 +1,11 @@
 import { render } from "/core/UI.js"
 import States from "/core/States.js"
 import SELECT from "/UI/components/select/index.js"
+import BaseElement from "/UI/BaseElement.js"
 import template from "./template.js"
 import logic from "./logic.js"
 
-export class GEO extends HTMLElement {
+export class GEO extends BaseElement {
     constructor() {
         super()
         this.states = new States({ id: null, country: null, current: null })
@@ -14,7 +15,6 @@ export class GEO extends HTMLElement {
         this.render = this.render.bind(this)
         this.clear = this.clear.bind(this)
         this.reset = this.reset.bind(this)
-        this.subscriptions = []
     }
 
     static get observedAttributes() {
@@ -27,12 +27,12 @@ export class GEO extends HTMLElement {
         this.render()
     }
 
-    async connectedCallback() {
+    async onConnect() {
         const country = this.shadowRoot.querySelector("#country")
         country.states.set({ options: await logic.countries() })
         country.props.change = event => this.states.set({ id: Number(event.target.value), current: country })
         if (!this.states.get("id") && this.dataset.id) this.states.set({ id: Number(this.dataset.id) })
-        this.subscriptions.push(this.states.on("id", this.render))
+        this.watch(this.states, "id", this.render)
     }
 
     async create({ id, selected } = {}) {

--- a/src/UI/components/header/index.js
+++ b/src/UI/components/header/index.js
@@ -1,16 +1,17 @@
 import template from "./template.js"
 import { render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class HEADER extends HTMLElement {
+export class HEADER extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
     }
 
-    connectedCallback() {
-        this.shadowRoot.querySelector(".games")?.addEventListener("click", () => {
+    onConnect() {
+        this.listen(this.shadowRoot.querySelector(".games"), "click", () => {
             logic.open()
         })
     }

--- a/src/UI/components/icon/index.js
+++ b/src/UI/components/icon/index.js
@@ -1,7 +1,8 @@
 import template from "./template.js"
 import { render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 
-export class ICON extends HTMLElement {
+export class ICON extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
@@ -12,7 +13,7 @@ export class ICON extends HTMLElement {
         return ["data-icon", "class"]
     }
 
-    connectedCallback() {
+    onConnect() {
         if (!this.dataset.icon) return
         this.render()
     }

--- a/src/UI/components/identicons/index.js
+++ b/src/UI/components/identicons/index.js
@@ -1,6 +1,7 @@
 import template from "./template.js"
 import { html, render } from "/core/UI.js"
 import Events from "/core/Events.js"
+import BaseElement from "/UI/BaseElement.js"
 
 const _workCache = new Map()
 
@@ -22,12 +23,11 @@ export async function cachedWork(data, salt) {
     return result
 }
 
-export class IDENTICONS extends HTMLElement {
+export class IDENTICONS extends BaseElement {
     constructor() {
         super()
         this.events = new Events()
         this.$subs = []
-        this.subscriptions = []
         this.$id = 0
         this.$savedId = 0
         this.$total = 0
@@ -58,7 +58,7 @@ export class IDENTICONS extends HTMLElement {
         }
     }
 
-    connectedCallback() {
+    onConnect() {
         this.$container = this.shadowRoot.querySelector("#container")
         this.$loader = this.shadowRoot.querySelector("#loader")
 
@@ -68,23 +68,14 @@ export class IDENTICONS extends HTMLElement {
             const delta = (e.deltaMode === 1 ? e.deltaY * 40 : e.deltaY) * 3
             this.$container.scrollBy({ left: delta, behavior: "auto" })
         }
-        this.$container.addEventListener("wheel", onWheel, { passive: false })
-        this.subscriptions.push(() => this.$container.removeEventListener("wheel", onWheel))
+        this.listen(this.$container, "wheel", onWheel, { passive: false })
 
         const onDecrease = () => this.events.emit("decrease")
         const onIncrease = () => this.events.emit("increase", { scrollToNew: true })
         const $dec = this.shadowRoot.querySelector("#status-decrease")
         const $inc = this.shadowRoot.querySelector("#status-increase")
-        $dec.addEventListener("click", onDecrease)
-        $inc.addEventListener("click", onIncrease)
-        this.subscriptions.push(
-            () => $dec.removeEventListener("click", onDecrease),
-            () => $inc.removeEventListener("click", onIncrease)
-        )
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
+        this.listen($dec, "click", onDecrease)
+        this.listen($inc, "click", onIncrease)
     }
 
     scrollTo(id, behavior = "instant") {

--- a/src/UI/components/item/index.js
+++ b/src/UI/components/item/index.js
@@ -3,18 +3,18 @@ import { Context } from "/core/Context.js"
 import States from "/core/States.js"
 import { render } from "/core/UI.js"
 import "/UI/components/game-item/index.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class ITEM extends HTMLElement {
+export class ITEM extends BaseElement {
     constructor() {
         super()
         this.states = new States()
         this.attachShadow({ mode: "open" })
-        this.subscriptions = []
         this.render = this.render.bind(this)
     }
 
-    async connectedCallback() {
+    async onConnect() {
         if ("item" in this.dataset) {
             const item = JSON.parse(this.dataset.item || "{}")
             const catalog = item.catalog || (item.game ? "game" : null)
@@ -39,7 +39,7 @@ export class ITEM extends HTMLElement {
         const key = this.dataset.key
         const { route: routePath } = logic.path(key)
         this.shadowRoot.querySelector("a[is='ui-a']").dataset.to = routePath
-        this.subscriptions.push(
+        this.subscribe(
             Context.on("locale", this.render),
             this.states.on("name", [name, "textContent"]),
             this.states.on("description", [description, "textContent"]),
@@ -53,10 +53,6 @@ export class ITEM extends HTMLElement {
         const data = await logic.meta(key)
         if (data) this.states.set(data)
         if (!this.states.has(["name", "price"])) this.render()
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 
     async render() {

--- a/src/UI/components/items/index.js
+++ b/src/UI/components/items/index.js
@@ -2,9 +2,10 @@ import template from "./template.js"
 import States from "/core/States.js"
 import ITEM from "/UI/components/item/index.js"
 import { render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class ITEMS extends HTMLElement {
+export class ITEMS extends BaseElement {
     constructor() {
         super()
         this.states = new States()
@@ -13,8 +14,8 @@ export class ITEMS extends HTMLElement {
         render(template, this.shadowRoot)
     }
 
-    async connectedCallback() {
-        this.states.on("pages", this.render)
+    async onConnect() {
+        this.subscribe(this.states.on("pages", this.render))
         const data = await logic.meta()
         if (data) this.states.set(data)
     }

--- a/src/UI/components/locales/index.js
+++ b/src/UI/components/locales/index.js
@@ -2,29 +2,24 @@ import template from "./template.js"
 import { Statics } from "/core/Stores.js"
 import { Context } from "/core/Context.js"
 import { render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class LOCALES extends HTMLElement {
+export class LOCALES extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
     }
 
-    connectedCallback() {
+    onConnect() {
         const button = this.shadowRoot.querySelector("ui-icon")
         const select = this.shadowRoot.querySelector("ui-picker")
 
-        button.addEventListener("click", select.show)
-        this.subscriptions.push(() => button.removeEventListener("click", select.show))
+        this.listen(button, "click", select.show)
 
         select.states.set({ options: logic.options(Statics.locales), selected: Context.get("locale")?.code })
         select.callback = (code) => Context.set({ locale: logic.find(code, Statics.locales) })
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 }
 

--- a/src/UI/components/navigator/index.js
+++ b/src/UI/components/navigator/index.js
@@ -1,15 +1,15 @@
 import template from "./template.js"
 import { render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 
-export class NAVIGATOR extends HTMLElement {
+export class NAVIGATOR extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
     }
 
-    connectedCallback() {
+    onConnect() {
         const state = this.shadowRoot.querySelector("#state")
         const label = this.shadowRoot.querySelector("label")
         const icon = this.shadowRoot.querySelector("ui-icon")
@@ -20,8 +20,7 @@ export class NAVIGATOR extends HTMLElement {
             if (this.dataset.icon) icon.dataset.icon = this.dataset.icon
             else delete icon.dataset.icon
 
-        label.addEventListener("click", vibrate)
-        this.subscriptions.push(() => label.removeEventListener("click", vibrate))
+        this.listen(label, "click", vibrate)
 
         const active = () => {
             let i = -1
@@ -33,8 +32,7 @@ export class NAVIGATOR extends HTMLElement {
             }
             el.style.setProperty("--active", i)
         }
-        state.addEventListener("change", active)
-        this.subscriptions.push(() => state.removeEventListener("change", active))
+        this.listen(state, "change", active)
 
         // Count the number of children in slot
         // Set --total for parent, and --i for each child
@@ -45,14 +43,9 @@ export class NAVIGATOR extends HTMLElement {
         children.forEach((child, i) => {
             child.style.setProperty("--i", i + 1)
             if (child.tagName !== "UI-NAVIGATOR") {
-                child.addEventListener("click", vibrate)
-                this.subscriptions.push(() => child.removeEventListener("click", vibrate))
+                this.listen(child, "click", vibrate)
             }
         })
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 }
 

--- a/src/UI/components/notifications/index.js
+++ b/src/UI/components/notifications/index.js
@@ -1,14 +1,14 @@
 import template from "./template.js"
 import { html, render } from "/core/UI.js"
 import { events } from "/core/Events.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class NOTIFICATIONS extends HTMLElement {
+export class NOTIFICATIONS extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.close = this.close.bind(this)
     }
 
@@ -17,8 +17,8 @@ export class NOTIFICATIONS extends HTMLElement {
         if (notification) this.shadowRoot.removeChild(notification)
     }
 
-    connectedCallback() {
-        this.subscriptions.push(
+    onConnect() {
+        this.subscribe(
             events.on("notify", ({ detail }) => {
                 const key = logic.key()
                 const close = () => this.close(key)
@@ -28,8 +28,7 @@ export class NOTIFICATIONS extends HTMLElement {
                         <ui-icon
                             data-icon="x-lg"
                             ${({ element }) => {
-                                element.addEventListener("click", close)
-                                this.subscriptions.push(() => element.removeEventListener("click", close))
+                                this.listen(element, "click", close)
                             }} />
                     </div>
                 `
@@ -38,10 +37,6 @@ export class NOTIFICATIONS extends HTMLElement {
                 setTimeout(close, detail?.delay || 5000)
             })
         )
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 }
 

--- a/src/UI/components/picker/index.js
+++ b/src/UI/components/picker/index.js
@@ -28,6 +28,12 @@ export class PICKER extends BaseElement {
         this.modal = this.shadowRoot.querySelector("ui-modal")
         this.modal.dataset.header = this.dataset.header
         this.watch(this.states, "options", this.render, true)
+        this.listen(this.modal, "change", (e) => {
+            if (e.target.type === "radio" && e.target.name === this.name) {
+                this.select(e.target.value)
+                this.modal.close()
+            }
+        })
     }
 
     show() {
@@ -58,24 +64,10 @@ export class PICKER extends BaseElement {
         // Create single template with all options
         const options = this.states
             .get("options")
-            .filter((option) => {
-                // Only process options that don't exist yet
-                const exist = this.modal.querySelector(`input[type="radio"][id="${option.value}"]`)
-                return !exist && option.value
-            })
             .map((option) => {
-                const select = () => {
-                    this.select(option.value)
-                    this.modal.close()
-                }
                 return html`
                     <input id="${option.value}" type="radio" name="${name}" value="${option.value}" ${option.value == this.selected ? "checked" : ""} />
-                    <label
-                        for="${option.value}"
-                        ${({ element }) => {
-                            element.addEventListener("click", select)
-                            this.subscriptions.push(() => element.removeEventListener("click", select))
-                        }}>
+                    <label for="${option.value}">
                         ${option.label}
                     </label>
                 `

--- a/src/UI/components/picker/index.js
+++ b/src/UI/components/picker/index.js
@@ -1,14 +1,14 @@
 import template from "./template.js"
 import States from "/core/States.js"
 import { html, render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 
-export class PICKER extends HTMLElement {
+export class PICKER extends BaseElement {
     constructor() {
         super()
         this.states = new States({ options: [], selected: null })
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.show = this.show.bind(this)
         this.close = this.close.bind(this)
         this.select = this.select.bind(this)
@@ -24,14 +24,10 @@ export class PICKER extends HTMLElement {
         this.states.set({ [name.replace("data-", "")]: value })
     }
 
-    connectedCallback() {
+    onConnect() {
         this.modal = this.shadowRoot.querySelector("ui-modal")
         this.modal.dataset.header = this.dataset.header
-        this.subscriptions.push(this.states.on("options", this.render, true))
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
+        this.watch(this.states, "options", this.render, true)
     }
 
     show() {

--- a/src/UI/components/pool/index.js
+++ b/src/UI/components/pool/index.js
@@ -4,14 +4,14 @@ import { Lives, Chains } from "/core/Stores.js"
 import { events } from "/core/Events.js"
 import { formatNumber, beautifyNumber } from "/core/Utils.js"
 import template from "./template.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class POOL extends HTMLElement {
+export class POOL extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.update = this.update.bind(this)
     }
 
@@ -23,17 +23,13 @@ export class POOL extends HTMLElement {
         return this.dataset.address
     }
 
-    connectedCallback() {
-        this.subscriptions.push(
+    onConnect() {
+        this.subscribe(
             events.on("Lives.pools", this.update),
             events.on("Lives.forex", this.update),
             Context.on("fiat", this.update)
         )
         this.update()
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 
     async update() {

--- a/src/UI/components/profile/index.js
+++ b/src/UI/components/profile/index.js
@@ -2,15 +2,15 @@ import { Elements } from "/core/Stores.js"
 import { Access } from "/core/Access.js"
 import { render } from "/core/UI.js"
 import template from "./template.js"
+import BaseElement from "/UI/BaseElement.js"
 import Logic from "/UI/components/user/logic.js"
 
-export class PROFILE extends HTMLElement {
+export class PROFILE extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         Elements.Profile = this
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.toggle = this.toggle.bind(this)
         this._renderIdentity = this._renderIdentity.bind(this)
     }
@@ -19,13 +19,12 @@ export class PROFILE extends HTMLElement {
         return this.shadowRoot.querySelector("ui-modal")
     }
 
-    connectedCallback() {
+    onConnect() {
         const $link = this.shadowRoot.querySelector("#profile-modal-link")
         const onLinkClick = () => this.modal.close()
-        $link.addEventListener("click", onLinkClick)
+        this.listen($link, "click", onLinkClick)
 
-        this.subscriptions.push(
-            () => $link.removeEventListener("click", onLinkClick),
+        this.subscribe(
             Access.on("authenticated", ({ value }) => {
                 if (!value) this.modal.close()
                 else this._renderIdentity()
@@ -33,10 +32,6 @@ export class PROFILE extends HTMLElement {
             Access.on("avatar", this._renderIdentity)
         )
         if (Access.get("authenticated")) this._renderIdentity()
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 
     toggle() {

--- a/src/UI/components/select/index.js
+++ b/src/UI/components/select/index.js
@@ -1,15 +1,15 @@
 import States from "/core/States.js"
 import { html, render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 import { template } from "./template.js"
 
-export class SELECT extends HTMLElement {
+export class SELECT extends BaseElement {
     constructor(props = {}) {
         super()
         this.props = props || {}
         this.states = new States({ options: props?.options || [], selected: props?.selected || null })
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.change = this.change.bind(this)
         this.render = this.render.bind(this)
     }
@@ -34,23 +34,16 @@ export class SELECT extends HTMLElement {
         }
     }
 
-    connectedCallback() {
+    onConnect() {
         this.select = this.select || this.shadowRoot.querySelector("select")
         this.select.setAttribute("name", this.props.name || this.dataset.name)
         this.placeholder = this.placeholder || this.shadowRoot.querySelectorAll("ui-context.placeholder")
         if (this.dataset.required || this.props.required) this.select.setAttribute("required", "required")
         if (this.dataset.name) this.select.setAttribute("name", this.dataset.name)
         this.placeholder.forEach(e => e.dataset.key = this.props.placeholder || this.dataset.placeholder || "")
-        this.select.addEventListener("change", this.change)
-        this.subscriptions.push(
-            this.states.on("options", this.render),
-            () => this.select.removeEventListener("change", this.change)
-        )
+        this.listen(this.select, "change", this.change)
+        this.watch(this.states, "options", this.render)
         this.render()
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 
     change(event) {

--- a/src/UI/components/signout/index.js
+++ b/src/UI/components/signout/index.js
@@ -1,31 +1,22 @@
 import { Elements } from "/core/Stores.js"
 import template from "./template.js"
 import { render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class SIGNOUT extends HTMLElement {
+export class SIGNOUT extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.toggle = this.toggle.bind(this)
         this.signout = this.signout.bind(this)
     }
 
-    connectedCallback() {
-        this.shadowRoot.querySelector("#signout").addEventListener("click", this.toggle)
-        this.shadowRoot.querySelector("#confirm").addEventListener("click", this.signout)
-        this.shadowRoot.querySelector("#back").addEventListener("click", this.toggle)
-        this.subscriptions.push(
-            () => this.shadowRoot.querySelector("#signout").removeEventListener("click", this.toggle),
-            () => this.shadowRoot.querySelector("#confirm").removeEventListener("click", this.signout),
-            () => this.shadowRoot.querySelector("#back").removeEventListener("click", this.toggle)
-        )
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
+    onConnect() {
+        this.listen(this.shadowRoot.querySelector("#signout"), "click", this.toggle)
+        this.listen(this.shadowRoot.querySelector("#confirm"), "click", this.signout)
+        this.listen(this.shadowRoot.querySelector("#back"), "click", this.toggle)
     }
 
     signout() {

--- a/src/UI/components/user/index.js
+++ b/src/UI/components/user/index.js
@@ -2,14 +2,14 @@ import { Elements } from "/core/Stores.js"
 import { Access } from "/core/Access.js"
 import template from "./template.js"
 import { render } from "/core/UI.js"
+import BaseElement from "/UI/BaseElement.js"
 import logic from "./logic.js"
 
-export class USER extends HTMLElement {
+export class USER extends BaseElement {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.toggle = this.toggle.bind(this)
         this.render = this.render.bind(this)
     }
@@ -18,20 +18,15 @@ export class USER extends HTMLElement {
         return this.shadowRoot.querySelector("ui-identicon")
     }
 
-    connectedCallback() {
-        this.shadowRoot.querySelector(".user").addEventListener("click", this.toggle)
-        this.subscriptions.push(
-            () => this.shadowRoot.querySelector(".user").removeEventListener("click", this.toggle),
+    onConnect() {
+        this.listen(this.shadowRoot.querySelector(".user"), "click", this.toggle)
+        this.subscribe(
             Access.on("authenticated", ({ value }) => {
                 if (!value) this.identicon.removeAttribute("data-seed")
             }),
             Access.on("avatar", this.render)
         )
         if (Access.get("authenticated")) this.render()
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 
     toggle() {

--- a/src/UI/components/wave/index.js
+++ b/src/UI/components/wave/index.js
@@ -157,6 +157,10 @@ export class WAVE extends HTMLElement {
         this.events.emit("stream", { stream: null })
         this.events.emit("analyser", { analyser: null })
         this.status.dataset.key = "dictionary.stopped"
+        if (this.audioContext) {
+            this.audioContext.close()
+            this.audioContext = null
+        }
     }
 
     sleep(ms = 0) {

--- a/src/UI/routes/checkout/index.js
+++ b/src/UI/routes/checkout/index.js
@@ -1,11 +1,9 @@
 import template from "./template.js"
-import { render } from "/core/UI.js"
+import BaseRoute from "/UI/BaseRoute.js"
 
-export class CHECKOUT extends HTMLElement {
+export class CHECKOUT extends BaseRoute {
     constructor() {
-        super()
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
+        super(template)
     }
 }
 

--- a/src/UI/routes/deposit/index.js
+++ b/src/UI/routes/deposit/index.js
@@ -1,29 +1,20 @@
 import template from "./template.js"
-import { render } from "/core/UI.js"
+import BaseRoute from "/UI/BaseRoute.js"
 import { Elements } from "/core/Stores.js"
 
-export class DEPOSIT extends HTMLElement {
+export class DEPOSIT extends BaseRoute {
     constructor() {
-        super()
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
-        this.subscriptions = []
+        super(template)
     }
 
-    async connectedCallback() {
+    async onConnect() {
         this.$wallets = this.shadowRoot.querySelector("ui-wallets")
-        this.subscriptions.push(
-            this.$wallets.states.on("address", async ({ value }) => {
-                const $qr = this.shadowRoot.querySelector("ui-qr")
-                if (!value) return
-                $qr.dataset.value = value
-            }, true)
-        )
+        this.watch(this.$wallets.states, "address", async ({ value }) => {
+            const $qr = this.shadowRoot.querySelector("ui-qr")
+            if (!value) return
+            $qr.dataset.value = value
+        }, true)
         Elements.Access?.checkpoint()
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 }
 

--- a/src/UI/routes/dispute/index.js
+++ b/src/UI/routes/dispute/index.js
@@ -1,11 +1,9 @@
 import template from "./template.js"
-import { render } from "/core/UI.js"
+import BaseRoute from "/UI/BaseRoute.js"
 
-export class DISPUTE extends HTMLElement {
+export class DISPUTE extends BaseRoute {
     constructor() {
-        super()
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
+        super(template)
     }
 }
 

--- a/src/UI/routes/home/index.js
+++ b/src/UI/routes/home/index.js
@@ -1,11 +1,9 @@
 import template from "./template.js"
-import { render } from "/core/UI.js"
+import BaseRoute from "/UI/BaseRoute.js"
 
-export class HOME extends HTMLElement {
+export class HOME extends BaseRoute {
     constructor() {
-        super()
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
+        super(template)
     }
 }
 

--- a/src/UI/routes/item/[game]/[item]/index.js
+++ b/src/UI/routes/item/[game]/[item]/index.js
@@ -5,33 +5,33 @@ import { html, render } from "/core/UI.js"
 import { notify } from "/core/Utils.js"
 import { States } from "/core/States.js"
 import Cart from "/core/Cart.js"
+import BaseRoute from "/UI/BaseRoute.js"
 import logic from "./logic.js"
 
-export class GAME_ITEM_ROUTE extends HTMLElement {
+export class GAME_ITEM_ROUTE extends BaseRoute {
     constructor() {
-        super()
+        super(template)
         const params = Context.get("params") || globalThis.history.state?.params || {}
         this.states = new States({ game: params.game, id: params.item })
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
-        this.subscriptions = []
         this.render = this.render.bind(this)
         this.increase = this.increase.bind(this)
         this.decrease = this.decrease.bind(this)
         this.add = this.add.bind(this)
     }
 
-    async connectedCallback() {
+    async onConnect() {
         const game = this.states.get("game")
         const id = this.states.get("id")
         const meta = await logic.meta(game, id)
         this.states.set({ meta })
-        this.subscriptions.push(Context.on("locale", this.render))
+        this.subscribe(Context.on("locale", this.render))
+        this.listen(this.shadowRoot.querySelector("#decrease"), "click", this.decrease)
+        this.listen(this.shadowRoot.querySelector("#increase"), "click", this.increase)
+        this.listen(this.shadowRoot.querySelector("#add"), "click", this.add)
         this.render()
     }
 
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
+    onDisconnect() {
         Context.del("item")
     }
 
@@ -164,15 +164,6 @@ export class GAME_ITEM_ROUTE extends HTMLElement {
             )
             render(attributes, root.querySelector("#attributes"))
         }
-
-        root.querySelector("#decrease").addEventListener("click", this.decrease)
-        root.querySelector("#increase").addEventListener("click", this.increase)
-        root.querySelector("#add").addEventListener("click", this.add)
-        this.subscriptions.push(
-            () => root.querySelector("#decrease").removeEventListener("click", this.decrease),
-            () => root.querySelector("#increase").removeEventListener("click", this.increase),
-            () => root.querySelector("#add").removeEventListener("click", this.add)
-        )
     }
 }
 

--- a/src/UI/routes/item/[item]/index.js
+++ b/src/UI/routes/item/[item]/index.js
@@ -5,30 +5,30 @@ import { html, render } from "/core/UI.js"
 import { notify } from "/core/Utils.js"
 import { States } from "/core/States.js"
 import Cart from "/core/Cart.js"
+import BaseRoute from "/UI/BaseRoute.js"
 import logic from "./logic.js"
 
-export class ITEM extends HTMLElement {
+export class ITEM extends BaseRoute {
     constructor() {
-        super()
+        super(template)
         this.states = new States({ id: Context.get("params").item || globalThis.history.state?.params?.item })
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
-        this.subscriptions = []
         this.render = this.render.bind(this)
         this.increase = this.increase.bind(this)
         this.decrease = this.decrease.bind(this)
         this.add = this.add.bind(this)
     }
 
-    async connectedCallback() {
+    async onConnect() {
         const meta = await logic.meta(this.states.get("id"))
         this.states.set({ meta })
-        this.subscriptions.push(Context.on("locale", this.render))
+        this.subscribe(Context.on("locale", this.render))
+        this.listen(this.shadowRoot.querySelector("#decrease"), "click", this.decrease)
+        this.listen(this.shadowRoot.querySelector("#increase"), "click", this.increase)
+        this.listen(this.shadowRoot.querySelector("#add"), "click", this.add)
         this.render()
     }
 
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
+    onDisconnect() {
         Context.del("item")
     }
 
@@ -165,15 +165,6 @@ export class ITEM extends HTMLElement {
             )
             render(attributes, root.querySelector("#attributes"))
         }
-
-        root.querySelector("#decrease").addEventListener("click", this.decrease)
-        root.querySelector("#increase").addEventListener("click", this.increase)
-        root.querySelector("#add").addEventListener("click", this.add)
-        this.subscriptions.push(
-            () => root.querySelector("#decrease").removeEventListener("click", this.decrease),
-            () => root.querySelector("#increase").removeEventListener("click", this.increase),
-            () => root.querySelector("#add").removeEventListener("click", this.add)
-        )
     }
 }
 

--- a/src/UI/routes/pools/index.js
+++ b/src/UI/routes/pools/index.js
@@ -3,16 +3,16 @@ import { render } from "/core/UI.js"
 import { Context } from "/core/Context.js"
 import { events } from "/core/Events.js"
 import { Indexes, Lives, Chains } from "/core/Stores.js"
+import BaseRoute from "/UI/BaseRoute.js"
 import logic from "./logic.js"
 
 const PAGE_SIZE = 25
 
-export class POOLS extends HTMLElement {
+export class POOLS extends BaseRoute {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
 
         this._elements = new Map()
         this._allRows = []
@@ -25,7 +25,7 @@ export class POOLS extends HTMLElement {
         this.loadMore = this.loadMore.bind(this)
     }
 
-    async connectedCallback() {
+    async onConnect() {
         const sr = this.shadowRoot
         this.$list = sr.querySelector("#list")
         this.$empty = sr.querySelector("#empty")
@@ -41,14 +41,14 @@ export class POOLS extends HTMLElement {
         this.$chainSelect = sr.querySelector("#chain-select")
         this.$dexPills = sr.querySelector("#dex-pills")
 
-        this.$loadMore.addEventListener("click", this.loadMore)
+        this.listen(this.$loadMore, "click", this.loadMore)
         this._initStickyObserver()
 
         await this.loadcache()
 
         // Subscribe before the final check — prevents missing an event that
         // fires between loadcache() completing and the listener being attached.
-        this.subscriptions.push(
+        this.subscribe(
             events.on("Lives.pools", this._onLivePools),
             Context.on("fiat", this._onFiat),
             Context.on("params", this._onParams)
@@ -57,8 +57,7 @@ export class POOLS extends HTMLElement {
         if (this._hasData) this._showData()
     }
 
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
+    onDisconnect() {
         if (this._stickyObserver) this._stickyObserver.disconnect()
     }
 

--- a/src/UI/routes/pools/index.js
+++ b/src/UI/routes/pools/index.js
@@ -1,5 +1,4 @@
 import template from "./template.js"
-import { render } from "/core/UI.js"
 import { Context } from "/core/Context.js"
 import { events } from "/core/Events.js"
 import { Indexes, Lives, Chains } from "/core/Stores.js"
@@ -10,9 +9,7 @@ const PAGE_SIZE = 25
 
 export class POOLS extends BaseRoute {
     constructor() {
-        super()
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
+        super(template)
 
         this._elements = new Map()
         this._allRows = []

--- a/src/UI/routes/profile/index.js
+++ b/src/UI/routes/profile/index.js
@@ -7,9 +7,7 @@ import logic, { SOCIAL_PLATFORMS } from "./logic.js"
 
 export class PROFILE extends BaseRoute {
     constructor() {
-        super()
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
+        super(template)
         this.states = new States({ name: "", bio: "", links: {}, following: [], editing: false, editingBio: false, editingLinks: false })
         this._followingSubs = []
         this._followingScope = null

--- a/src/UI/routes/profile/index.js
+++ b/src/UI/routes/profile/index.js
@@ -2,15 +2,15 @@ import template from "./template.js"
 import { html, render } from "/core/UI.js"
 import { Access } from "/core/Access.js"
 import States from "/core/States.js"
+import BaseRoute from "/UI/BaseRoute.js"
 import logic, { SOCIAL_PLATFORMS } from "./logic.js"
 
-export class PROFILE extends HTMLElement {
+export class PROFILE extends BaseRoute {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
         this.states = new States({ name: "", bio: "", links: {}, following: [], editing: false, editingBio: false, editingLinks: false })
-        this.subscriptions = []
         this._followingSubs = []
         this._followingScope = null
         this._enterEditMode = this._enterEditMode.bind(this)
@@ -23,7 +23,7 @@ export class PROFILE extends HTMLElement {
         this._exitLinksEditMode = this._exitLinksEditMode.bind(this)
     }
 
-    connectedCallback() {
+    onConnect() {
         const $ = (id) => this.shadowRoot.querySelector(id)
 
         // Wire name edit controls
@@ -32,22 +32,14 @@ export class PROFILE extends HTMLElement {
         const $cancelBtn = $("#profile-name-cancel")
         const $input = $("#profile-name-input")
 
-        $editBtn.addEventListener("click", this._enterEditMode)
-        $saveBtn.addEventListener("click", () => this._exitEditMode(true))
-        $cancelBtn.addEventListener("click", () => this._exitEditMode(false))
-        $input.addEventListener("keydown", this._onKeydown)
-
-        this.subscriptions.push(
-            () => $editBtn.removeEventListener("click", this._enterEditMode),
-            () => $saveBtn.removeEventListener("click", () => this._exitEditMode(true)),
-            () => $cancelBtn.removeEventListener("click", () => this._exitEditMode(false)),
-            () => $input.removeEventListener("keydown", this._onKeydown)
-        )
+        this.listen($editBtn, "click", this._enterEditMode)
+        this.listen($saveBtn, "click", () => this._exitEditMode(true))
+        this.listen($cancelBtn, "click", () => this._exitEditMode(false))
+        this.listen($input, "keydown", this._onKeydown)
 
         // Wire follow form
         const $form = $("#profile-follow-form")
-        $form.addEventListener("submit", this._onFollowSubmit)
-        this.subscriptions.push(() => $form.removeEventListener("submit", this._onFollowSubmit))
+        this.listen($form, "submit", this._onFollowSubmit)
 
         // Wire bio edit controls
         const $bioEdit = $("#profile-bio-edit")
@@ -58,16 +50,10 @@ export class PROFILE extends HTMLElement {
         const updateBioCount = () => {
             $bioCount.textContent = 360 - $bioInput.value.length
         }
-        $bioEdit.addEventListener("click", this._enterBioEditMode)
-        $bioSave.addEventListener("click", () => this._exitBioEditMode(true))
-        $bioCancel.addEventListener("click", () => this._exitBioEditMode(false))
-        $bioInput.addEventListener("input", updateBioCount)
-        this.subscriptions.push(
-            () => $bioEdit.removeEventListener("click", this._enterBioEditMode),
-            () => $bioSave.removeEventListener("click", () => this._exitBioEditMode(true)),
-            () => $bioCancel.removeEventListener("click", () => this._exitBioEditMode(false)),
-            () => $bioInput.removeEventListener("input", updateBioCount)
-        )
+        this.listen($bioEdit, "click", this._enterBioEditMode)
+        this.listen($bioSave, "click", () => this._exitBioEditMode(true))
+        this.listen($bioCancel, "click", () => this._exitBioEditMode(false))
+        this.listen($bioInput, "input", updateBioCount)
 
         // Wire avatar picker
         const $avatarEdit = $("#profile-avatar-edit")
@@ -98,11 +84,9 @@ export class PROFILE extends HTMLElement {
             _originalAvatarId = null
         }
 
-        $avatarEdit.addEventListener("click", openPicker)
-        $avatarBackdrop.addEventListener("click", () => closePicker(true))
-        this.subscriptions.push(
-            () => $avatarEdit.removeEventListener("click", openPicker),
-            () => $avatarBackdrop.removeEventListener("click", () => closePicker(true)),
+        this.listen($avatarEdit, "click", openPicker)
+        this.listen($avatarBackdrop, "click", () => closePicker(true))
+        this.subscribe(
             $avatars.events.on("accept", () => closePicker(false)),
             $avatars.events.on("cancel", () => closePicker(true))
         )
@@ -111,17 +95,12 @@ export class PROFILE extends HTMLElement {
         const $linksEdit = $("#profile-links-edit")
         const $linksSave = $("#profile-links-save")
         const $linksCancel = $("#profile-links-cancel")
-        $linksEdit.addEventListener("click", this._enterLinksEditMode)
-        $linksSave.addEventListener("click", () => this._exitLinksEditMode(true))
-        $linksCancel.addEventListener("click", () => this._exitLinksEditMode(false))
-        this.subscriptions.push(
-            () => $linksEdit.removeEventListener("click", this._enterLinksEditMode),
-            () => $linksSave.removeEventListener("click", () => this._exitLinksEditMode(true)),
-            () => $linksCancel.removeEventListener("click", () => this._exitLinksEditMode(false))
-        )
+        this.listen($linksEdit, "click", this._enterLinksEditMode)
+        this.listen($linksSave, "click", () => this._exitLinksEditMode(true))
+        this.listen($linksCancel, "click", () => this._exitLinksEditMode(false))
 
         // Subscribe to auth changes
-        this.subscriptions.push(
+        this.subscribe(
             Access.on("authenticated", async ({ value }) => {
                 this._applyAuthState(value)
                 if (value) {
@@ -160,8 +139,7 @@ export class PROFILE extends HTMLElement {
         }
     }
 
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
+    onDisconnect() {
         this._followingSubs.forEach((off) => off())
         this._followingScope?.off?.()
     }

--- a/src/UI/routes/showcase/index.js
+++ b/src/UI/routes/showcase/index.js
@@ -1,24 +1,18 @@
 import template from "./template.js"
-import { render } from "/core/UI.js"
+import BaseRoute from "/UI/BaseRoute.js"
 import stories from "./stories/index.js"
 
-export class SHOWCASE extends HTMLElement {
+export class SHOWCASE extends BaseRoute {
     constructor() {
-        super()
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
+        super(template)
         this._stories = stories
         this._onHashChange = this._onHashChange.bind(this)
     }
 
-    connectedCallback() {
+    onConnect() {
         this._renderSidebar()
         this._renderCanvas()
-        globalThis.addEventListener("hashchange", this._onHashChange)
-    }
-
-    disconnectedCallback() {
-        globalThis.removeEventListener("hashchange", this._onHashChange)
+        this.listen(globalThis, "hashchange", this._onHashChange)
     }
 
     _currentGroup() {

--- a/src/UI/routes/swap/index.js
+++ b/src/UI/routes/swap/index.js
@@ -4,20 +4,20 @@ import { Context } from "/core/Context.js"
 import { events } from "/core/Events.js"
 import { Elements, Lives, Chains, Dexs, Wallets } from "/core/Stores.js"
 import { notify, formatNumber } from "/core/Utils.js"
+import BaseRoute from "/UI/BaseRoute.js"
 import SELECT from "/UI/components/select/index.js"
 import logic from "./logic.js"
 
-export class SWAP extends HTMLElement {
+export class SWAP extends BaseRoute {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.quote = this.quote.bind(this)
         this.submit = this.submit.bind(this)
     }
 
-    connectedCallback() {
+    onConnect() {
         this.$wallets = this.shadowRoot.querySelector("ui-wallets")
         this.$amountIn = this.shadowRoot.querySelector("#amount-in")
         this.$quoteOut = this.shadowRoot.querySelector("#quote-out")
@@ -56,10 +56,10 @@ export class SWAP extends HTMLElement {
         })
         render(this.$toToken, this.shadowRoot.querySelector("#to-token"), { append: true })
 
-        this.$amountIn.addEventListener("input", this.quote)
-        this.$submit.addEventListener("click", this.submit)
+        this.listen(this.$amountIn, "input", this.quote)
+        this.listen(this.$submit, "click", this.submit)
 
-        this.subscriptions.push(
+        this.subscribe(
             this.$wallets.states.on("address", ({ value }) => {
                 const active = !!value
                 this.$amountIn.disabled = !active
@@ -73,11 +73,7 @@ export class SWAP extends HTMLElement {
                 }
             }, true),
             this.$wallets.states.on("chain", () => this.options()),
-            events.on("Lives.pools", () => this.options()),
-            () => {
-                this.$amountIn.removeEventListener("input", this.quote)
-                this.$submit.removeEventListener("click", this.submit)
-            }
+            events.on("Lives.pools", () => this.options())
         )
 
         const params = Context.get("params") || {}
@@ -85,10 +81,6 @@ export class SWAP extends HTMLElement {
         if (params.to) this.$pto = params.to
 
         Elements.Access?.checkpoint()
-    }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 
     options() {

--- a/src/UI/routes/swap/index.js
+++ b/src/UI/routes/swap/index.js
@@ -10,9 +10,7 @@ import logic from "./logic.js"
 
 export class SWAP extends BaseRoute {
     constructor() {
-        super()
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
+        super(template)
         this.quote = this.quote.bind(this)
         this.submit = this.submit.bind(this)
     }

--- a/src/UI/routes/test/index.js
+++ b/src/UI/routes/test/index.js
@@ -1,5 +1,5 @@
 import template from "./template.js"
-import { render } from "/core/UI.js"
+import BaseRoute from "/UI/BaseRoute.js"
 
 const TEST_MODULES = [
     "/core/tests/Events.test.js",
@@ -21,21 +21,19 @@ const TEST_MODULES = [
     "/core/tests/OPFS.test.js",
 ]
 
-export class TEST extends HTMLElement {
+export class TEST extends BaseRoute {
     constructor() {
-        super()
+        super(template)
         this._results = []   // { suiteName, tests: [...], status }
         this._totals = { passed: 0, failed: 0, skipped: 0, total: 0 }
         this._running = false
         this._openSuites = new Set()
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
     }
 
-    connectedCallback() {
+    onConnect() {
         const root = this.shadowRoot
-        root.getElementById("run-all").addEventListener("click", () => this._runAll())
-        root.getElementById("run-failed").addEventListener("click", () => this._runFailed())
+        this.listen(root.getElementById("run-all"), "click", () => this._runAll())
+        this.listen(root.getElementById("run-failed"), "click", () => this._runFailed())
         this._runAll()
     }
 

--- a/src/UI/routes/withdraw/index.js
+++ b/src/UI/routes/withdraw/index.js
@@ -1,5 +1,4 @@
 import template from "./template.js"
-import { render } from "/core/UI.js"
 import { Context } from "/core/Context.js"
 import { notify } from "/core/Utils.js"
 import { Elements, Wallets } from "/core/Stores.js"
@@ -8,9 +7,7 @@ import logic from "./logic.js"
 
 export class WITHDRAW extends BaseRoute {
     constructor() {
-        super()
-        this.attachShadow({ mode: "open" })
-        render(template, this.shadowRoot)
+        super(template)
         this.submit = this.submit.bind(this)
         this.estimateGas = this.estimateGas.bind(this)
     }
@@ -43,6 +40,9 @@ export class WITHDRAW extends BaseRoute {
 
         Elements.Access?.checkpoint()
     }
+
+    onDisconnect() {
+        clearTimeout(this.$gaspend)
     }
 
     estimateGas() {

--- a/src/UI/routes/withdraw/index.js
+++ b/src/UI/routes/withdraw/index.js
@@ -3,33 +3,32 @@ import { render } from "/core/UI.js"
 import { Context } from "/core/Context.js"
 import { notify } from "/core/Utils.js"
 import { Elements, Wallets } from "/core/Stores.js"
+import BaseRoute from "/UI/BaseRoute.js"
 import logic from "./logic.js"
 
-export class WITHDRAW extends HTMLElement {
+export class WITHDRAW extends BaseRoute {
     constructor() {
         super()
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
-        this.subscriptions = []
         this.submit = this.submit.bind(this)
         this.estimateGas = this.estimateGas.bind(this)
     }
 
-    connectedCallback() {
+    onConnect() {
         this.$wallets = this.shadowRoot.querySelector("ui-wallets")
         this.$form = this.shadowRoot.querySelector("#form")
         this.$gas = this.shadowRoot.querySelector("#gas")
         const $submit = this.shadowRoot.querySelector("#submit")
 
         this.$form.querySelectorAll("input[type='text'], input[type='number']").forEach((input) => {
-            this.subscriptions.push(Context.on(["dictionary", input.name], [input, "placeholder"]))
-            input.addEventListener("input", this.estimateGas)
-            this.subscriptions.push(() => input.removeEventListener("input", this.estimateGas))
+            this.subscribe(Context.on(["dictionary", input.name], [input, "placeholder"]))
+            this.listen(input, "input", this.estimateGas)
         })
 
-        $submit.addEventListener("click", this.submit)
+        this.listen($submit, "click", this.submit)
 
-        this.subscriptions.push(
+        this.subscribe(
             this.$wallets.states.on("address", ({ value }) => {
                 this.$form.querySelectorAll("input").forEach((el) => (el.disabled = !value))
                 $submit.toggleAttribute("disabled", !value)
@@ -39,15 +38,11 @@ export class WITHDRAW extends HTMLElement {
                 } else 
                     this.estimateGas()
                 
-            }, true),
-            () => $submit.removeEventListener("click", this.submit)
+            }, true)
         )
 
         Elements.Access?.checkpoint()
     }
-
-    disconnectedCallback() {
-        this.subscriptions.forEach((off) => off())
     }
 
     estimateGas() {


### PR DESCRIPTION
## Summary

This PR introduces two shared base classes — `BaseElement` and `BaseRoute` — that centralize the repetitive lifecycle boilerplate across every web component and route in the UI layer. All 30+ components and routes that previously managed their own `subscriptions` arrays, `connectedCallback`/`disconnectedCallback` wiring, and manual event listener teardown have been migrated to the new abstraction, eliminating roughly 400 lines of duplicated scaffolding.

---

## BaseElement and BaseRoute

`BaseElement` (`src/UI/BaseElement.js`) extends `HTMLElement` and provides three lifecycle helpers: `subscribe(...fns)` registers arbitrary cleanup functions, `listen(target, event, handler)` attaches an event listener and auto-registers its remover, and `watch(observable, key, cb, immediate)` wraps `Context.on` / `States.on` subscriptions. All registered cleanups run automatically in `disconnectedCallback`, which calls the overridable `onDisconnect()` hook first. `BaseRoute` extends `BaseElement` with shadow DOM setup — `attachShadow` and the initial `render(template, this.shadowRoot)` call are handled in `super(template)`, and convenience `query()`/`queryAll()` helpers wrap `this.shadowRoot.querySelector`.

Subclasses override `onConnect()` and `onDisconnect()` instead of the raw `connectedCallback`/`disconnectedCallback`. This eliminates the need to declare `this.subscriptions = []` in every constructor and guarantees cleanup always runs even if a subclass forgets to call `super`.

---

## Component and Route Migration

Every component under `src/UI/components/` and every route under `src/UI/routes/` that previously managed its own subscription array was migrated. The constructor pattern collapses from five to three lines — `super()`, the shadow DOM attach, and the initial render are replaced by `super(template)` for routes, or a plain `super()` for components that don't use `BaseRoute`. Event listener registration moves from repeated `addEventListener`/push-to-subscriptions pairs into single `this.listen()` calls, and `Context.on`/`States.on` calls are wrapped with `this.subscribe()` or `this.watch()`.

Several components received targeted fixes during migration: `ui-cart` had per-render listener accumulation — `this.listen()` was being called inside `render()` on every state update, leaking closures onto replaced DOM nodes — which was corrected by moving to a single delegated `click` listener on the modal container in `onConnect()`. `ui-picker` dropped incremental DOM patching in favour of a full re-render on each options change plus a single delegated `change` listener. `ui-addresses` now correctly tears down its GunDB scope subscription. The `wave` component closes its `AudioContext` on stop. Routes `dispute`, `item/[item]`, and `item/[game]/[item]` had syntax errors introduced during the earlier batch migration (missing closing braces) that are corrected here.

---

## Test Plan

- [ ] Navigate to an item route (`/en/item/:id`) — page renders, quantity stepper and add-to-cart work, locale switch re-renders correctly
- [ ] Navigate to a game-item route (`/en/item/:game/:id`) — same as above; breadcrumb and back link populated
- [ ] Open cart modal — items render with correct quantities; `+`, `−`, and `×` buttons update cart state without duplicate firings after multiple renders
- [ ] Open picker component — radio options render, selecting one closes the modal and fires the callback
- [ ] Navigate between routes repeatedly — no subscription leaks (Context listener count should not grow on each visit)
- [ ] Dispute route renders without a JS error
- [ ] Pools, swap, withdraw, and profile routes load and function normally
- [ ] Wave component: start and stop audio stream — `AudioContext` is closed on stop with no console errors
