### PR TITLE
fix(sync): pin raw.yaml popularity to existing value to prevent build churn

### DIFF
--- a/builder/games/sync.js
+++ b/builder/games/sync.js
@@ -3,7 +3,7 @@
  * and their compiled JSON to build/statics/items/<game-id>/<item-id>/.
  *
  * Responsibilities:
- *   - write raw.yaml per item (crawler data, icon field stripped)
+ *   - write raw.yaml per item (crawler data, popularity pinned to existing value)
  *   - sync YAML sources to src/ (non-destructive: patch meta.yaml, create locale only if missing)
  *   - compile JSON to build/ (non-destructive: patch meta.json, create locale only if missing)
  *
@@ -278,8 +278,11 @@ async function syncItem(gameId, itemId, raw, meta, localeData, localeCodes, sour
     const srcDir = [...paths.src.items, gameId, itemId]
     const buildDir = [...paths.build.statics, "items", gameId, itemId]
 
-    // ── raw.yaml (always overwrite: tracks latest crawler output, verbatim) ──
-    await FS.write([...srcDir, "raw.yaml"], raw)
+    // ── raw.yaml (always overwrite: tracks latest crawler output, popularity pinned to existing) ──
+    const rawYamlPath = [...srcDir, "raw.yaml"]
+    const existingRaw = (await FS.exist(rawYamlPath)) ? await FS.load(rawYamlPath) : null
+    const rawToWrite = existingRaw?.popularity != null ? { ...raw, popularity: existingRaw.popularity } : raw
+    await FS.write(rawYamlPath, rawToWrite)
 
     // ── images: hash-based dedupe, append new, mirror to build ──
     stats.imagesSeeded += await syncItemImages(gameId, srcDir, sourceImageMap)


### PR DESCRIPTION
## fix: pin `raw.yaml` popularity to prevent build churn

`build:games` was always rewriting `raw.yaml` verbatim from the latest crawler output, including the `popularity` field — a volatile ranking metric that changes on every crawl. This caused hundreds of `raw.yaml` files to appear modified after every build with no meaningful structural change.

**Change:** When writing `raw.yaml`, preserve the existing `popularity` value if the file already exists. New items still get their initial `popularity` written from the crawler.

**Why `popularity` specifically:** It was already excluded from the canonical item ID hash (`buildCanonicalItemId`) for the same stability reason — this change extends that intent to the file write.

The field is kept in `raw.yaml` as-is; a separate script will handle manual bulk updates when needed.
