### PR TITLE
feat(wallets): add pencil edit affordance, deposit/withdraw routes, and semantic warning tokens

### DIFF
--- a/docs/debts/20260421.md
+++ b/docs/debts/20260421.md
@@ -1,0 +1,26 @@
+# Technical Debt: Hardcoded chain→token standard map in wallets UI
+
+**Discovered**: 2026-04-21  
+**PR**: #60  
+**Status**: Known Issue — Accepted (temporary)
+
+---
+
+## Issue
+
+`src/UI/components/wallets/index.js` currently hardcodes `TOKEN_STANDARD`:
+
+- `1`, `11155111` → `ERC20`
+- `56`, `97` → `BEP20`
+
+This is a brittle UI-level mapping and can drift from actual chain metadata.
+
+## Repayment Plan
+
+1. Move token-standard metadata into static chain data (`statics/chains`).
+2. Read standard from selected chain config instead of local constants.
+3. Keep a safe fallback label only when metadata is missing.
+
+## Related File
+
+- `src/UI/components/wallets/index.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -659,7 +659,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -838,7 +837,6 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2574,7 +2572,6 @@
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -2589,7 +2586,6 @@
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },

--- a/src/UI/components/identicons/styles.css.js
+++ b/src/UI/components/identicons/styles.css.js
@@ -11,9 +11,10 @@ export const styles = css`
 
     #scroll-wrap {
         flex: 1;
-        min-height: 0;
+        min-height: var(--icon-lg);
         position: relative;
         overflow: hidden;
+        padding-block: var(--space-3);
     }
 
     #container {
@@ -32,19 +33,28 @@ export const styles = css`
 
         /* hide scrollbar on touch devices */
         scrollbar-width: none;
-        &::-webkit-scrollbar { display: none; }
+        &::-webkit-scrollbar {
+            display: none;
+        }
 
         @media (min-width: ${bp.sm + 1}px) {
             scrollbar-width: thin;
             scrollbar-color: color-mix(in hsl, var(--color) 25%, transparent) transparent;
             padding-bottom: var(--space-3);
 
-            &::-webkit-scrollbar { display: block; height: 3px; }
-            &::-webkit-scrollbar-track { background: transparent; }
+            &::-webkit-scrollbar {
+                display: block;
+                height: 3px;
+            }
+            &::-webkit-scrollbar-track {
+                background: transparent;
+            }
             &::-webkit-scrollbar-thumb {
                 background: color-mix(in hsl, var(--color) 25%, transparent);
                 border-radius: 99px;
-                &:hover { background: color-mix(in hsl, var(--color) 50%, transparent); }
+                &:hover {
+                    background: color-mix(in hsl, var(--color) 50%, transparent);
+                }
             }
         }
 
@@ -154,9 +164,24 @@ export const styles = css`
     }
 
     @keyframes identicons-switch-splash {
-        0%   { outline-offset: var(--space-1); box-shadow: 0 0 8px hsl(var(--item-hue) 100% 65% / 53%), 0 0 24px hsl(var(--item-hue) 100% 65% / 20%); }
-        40%  { outline-offset: 10px;           box-shadow: 0 0 18px hsl(var(--item-hue) 100% 65% / 70%), 0 0 48px hsl(var(--item-hue) 100% 65% / 35%); }
-        100% { outline-offset: var(--space-1); box-shadow: 0 0 8px hsl(var(--item-hue) 100% 65% / 53%), 0 0 24px hsl(var(--item-hue) 100% 65% / 20%); }
+        0% {
+            outline-offset: var(--space-1);
+            box-shadow:
+                0 0 8px hsl(var(--item-hue) 100% 65% / 53%),
+                0 0 24px hsl(var(--item-hue) 100% 65% / 20%);
+        }
+        40% {
+            outline-offset: 10px;
+            box-shadow:
+                0 0 18px hsl(var(--item-hue) 100% 65% / 70%),
+                0 0 48px hsl(var(--item-hue) 100% 65% / 35%);
+        }
+        100% {
+            outline-offset: var(--space-1);
+            box-shadow:
+                0 0 8px hsl(var(--item-hue) 100% 65% / 53%),
+                0 0 24px hsl(var(--item-hue) 100% 65% / 20%);
+        }
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -184,7 +209,6 @@ export const styles = css`
         user-select: none;
         pointer-events: none;
         flex-shrink: 0;
-        min-height: 2.75rem;
         border-bottom: var(--border-width) solid color-mix(in hsl, var(--color) 10%, transparent);
     }
 
@@ -201,7 +225,7 @@ export const styles = css`
     .status-right {
         display: flex;
         align-items: center;
-        flex: 1;
+        flex: var(--identicons-status-right-flex, 0 0 auto);
         min-width: 0;
         gap: var(--space-1);
 
@@ -215,16 +239,22 @@ export const styles = css`
 
     /* ── Mode visibility ── */
     /* carousel controls visible by default; hidden in picker mode */
-    :host([data-mode="picker"]) .status-nav-btn--carousel { display: none; }
+    :host([data-mode="picker"]) .status-nav-btn--carousel {
+        display: none;
+    }
     /* add button hidden by default; visible only in picker mode */
-    .status-nav-btn--picker { display: none; }
+    .status-nav-btn--picker {
+        display: none;
+    }
     :host([data-mode="picker"]) .status-nav-btn--picker {
         display: inline-flex;
         justify-content: flex-start;
     }
 
     .status-item {
-        &[hidden] { display: none; }
+        &[hidden] {
+            display: none;
+        }
         display: flex;
         align-items: center;
         gap: var(--space-1);
@@ -254,6 +284,11 @@ export const styles = css`
         font-size: 0.85em;
     }
 
+    #status-add {
+        min-width: unset;
+        padding-right: var(--space-3);
+    }
+
     .status-sep {
         opacity: 0.25;
         margin: 0 var(--space-1);
@@ -276,7 +311,9 @@ export const styles = css`
         cursor: pointer;
         pointer-events: all;
         color: var(--neon-g);
-        transition: opacity var(--speed), filter var(--speed);
+        transition:
+            opacity var(--speed),
+            filter var(--speed);
 
         ui-svg {
             width: var(--icon-sm);

--- a/src/UI/components/modal/index.js
+++ b/src/UI/components/modal/index.js
@@ -27,15 +27,28 @@ export class MODAL extends HTMLElement {
     connectedCallback() {
         this.dialog = this.shadowRoot.querySelector("dialog")
         this.shadowRoot.querySelectorAll("dialog, .close, footer").forEach((el) => el.addEventListener("click", this.click))
+        this.dialog.addEventListener("cancel", this.cancel)
         this.shadowRoot.querySelector("#header").dataset.key = `dictionary.${this.dataset.header}`
     }
 
     disconnectedCallback() {
         this.shadowRoot.querySelectorAll("dialog, .close, footer").forEach((el) => el.removeEventListener("click", this.click))
+        this.dialog.removeEventListener("cancel", this.cancel)
     }
 
     click = (event) => {
+        if (this._required) return
         if ([...this.shadowRoot.querySelectorAll("dialog, .close, footer")].includes(event.composedPath?.()?.[0])) this.dialog.close()
+    }
+
+    cancel = (event) => {
+        if (this._required) event.preventDefault()
+    }
+
+    setRequired(required) {
+        this._required = required
+        const footer = this.shadowRoot.querySelector("footer")
+        if (footer) footer.style.visibility = required ? "hidden" : ""
     }
 
     show() {

--- a/src/UI/components/modal/styles.css.js
+++ b/src/UI/components/modal/styles.css.js
@@ -27,6 +27,8 @@ export const styles = css`
             background: none;
             border: none;
             overflow: hidden;
+            user-select: none;
+            outline: none;
             animation: in var(--speed) ease-in-out none;
 
             &::backdrop {
@@ -91,6 +93,7 @@ export const styles = css`
                     }
                 }
             }
+
 
             section {
                 display: block;

--- a/src/UI/components/picker/styles.css.js
+++ b/src/UI/components/picker/styles.css.js
@@ -15,8 +15,8 @@ export const styles = css`
 
             section {
                 padding: 0;
-                border-color: color-mix(in hsl, var(--accent-info) 35%, transparent);
-                box-shadow: 0 0 32px color-mix(in hsl, var(--accent-info) 12%, transparent);
+                border-color: var(--accent-info-border);
+                box-shadow: 0 0 32px var(--accent-info-glow);
                 overflow-y: auto;
             }
         }
@@ -72,7 +72,7 @@ export const styles = css`
             transition: background var(--speed), color var(--speed);
             &:last-of-type { border-bottom: none; }
             &:hover {
-                background: color-mix(in hsl, var(--accent-info) 8%, transparent);
+                background: var(--accent-info-surface);
                 color: var(--accent-info);
             }
         }

--- a/src/UI/components/qr/styles.css.js
+++ b/src/UI/components/qr/styles.css.js
@@ -15,7 +15,7 @@ export const styles = css`
 
         #qr {
             display: flex;
-            background: var(--color-accent);
+            background: #ffffff;
             padding: var(--space);
             svg {
                 width: 100%;

--- a/src/UI/components/search/styles.css.js
+++ b/src/UI/components/search/styles.css.js
@@ -92,7 +92,7 @@ export const styles = css`
 
         &:hover,
         &.highlighted {
-            background: color-mix(in hsl, var(--accent-info) 8%, transparent);
+            background: var(--accent-info-surface);
         }
     }
 

--- a/src/UI/components/swap-form/styles.css.js
+++ b/src/UI/components/swap-form/styles.css.js
@@ -212,14 +212,14 @@ export const styles = css`
         align-items: center;
         justify-content: space-between;
         gap: var(--space-2);
-        min-width: 9.5rem;
-        min-height: 2.75rem;
-        padding: var(--space-2) var(--space-4);
+        min-width: 8rem;
+        min-height: 2.25rem;
+        padding: var(--space-1) var(--space-3);
         background: transparent;
         border: 1px solid color-mix(in hsl, var(--color) 25%, transparent);
         color: var(--color);
         font-family: var(--header-font);
-        font-size: var(--text-md);
+        font-size: var(--text-sm);
         letter-spacing: 0.08em;
         text-transform: uppercase;
         cursor: pointer;
@@ -267,9 +267,9 @@ export const styles = css`
         }
 
         .trigger-icon {
-            width: 1.25rem;
-            height: 1.25rem;
-            min-width: 1.25rem;
+            width: 1rem;
+            height: 1rem;
+            min-width: 1rem;
             flex-shrink: 0;
         }
 
@@ -401,8 +401,8 @@ export const styles = css`
     }
 
     #submit {
-        --btn-bg: color-mix(in hsl, var(--accent-action) 12%, transparent);
-        --btn-border: var(--border-width) solid color-mix(in hsl, var(--accent-action) 50%, transparent);
+        --btn-bg: var(--accent-action-surface);
+        --btn-border: var(--border-width) solid var(--accent-action-border);
         --btn-radius: 0;
         --btn-padding: var(--space-sm) var(--space);
         --btn-color: var(--accent-action);
@@ -415,7 +415,7 @@ export const styles = css`
         --btn-color-hover: var(--accent-action);
         --btn-border-color-hover: var(--accent-action);
         --btn-glow-hover: var(--glow-action);
-        box-shadow: 0 0 10px color-mix(in hsl, var(--accent-action) 20%, transparent);
+        box-shadow: 0 0 10px var(--accent-action-glow);
         &[disabled] {
             opacity: 0.35;
             cursor: not-allowed;

--- a/src/UI/components/wallets/index.js
+++ b/src/UI/components/wallets/index.js
@@ -1,14 +1,20 @@
 /* eslint-disable curly */
 import template from "./template.js"
 import { Access } from "/core/Access.js"
-import { html, render } from "/core/UI.js"
+import { render } from "/core/UI.js"
 import { Chains, Lives, Wallets } from "/core/Stores.js"
 import States from "/core/States.js"
 import { Context } from "/core/Context.js"
-import SELECT from "/UI/components/select/index.js"
 import { notify, formatBalance } from "/core/Utils.js"
 import { sha256 } from "/core/Utils/crypto.js"
 import logic from "./logic.js"
+
+const TOKEN_STANDARD = {
+    1: "ERC20",       // Ethereum
+    11155111: "ERC20", // Sepolia
+    56: "BEP20",      // BSC
+    97: "BEP20"       // BSC Testnet
+}
 
 export class WALLETS extends HTMLElement {
     static module = import.meta.url
@@ -19,7 +25,8 @@ export class WALLETS extends HTMLElement {
         this.states = new States({
             chain: Context.get("params")?.chain || null,
             currency: Context.get("params")?.currency || null,
-            address: null
+            address: null,
+            balance: null
         })
         this.attachShadow({ mode: "open" })
         render(template, this.shadowRoot)
@@ -27,7 +34,8 @@ export class WALLETS extends HTMLElement {
         this.step = 5
         this.change = this.change.bind(this)
 
-        // Holds the current chain options array so trigger/modal can look up names
+        // Holds the current currency/chain options arrays so triggers can look up names
+        this._currencyOptions = []
         this._chainOptions = []
         // Wallet being previewed (selected but not yet committed); null = resting
         this._previewId = null
@@ -56,6 +64,11 @@ export class WALLETS extends HTMLElement {
     async connectedCallback() {
         // ── DOM refs ──────────────────────────────────────────────
         this.$identicons = this.shadowRoot.querySelector("ui-identicons")
+        this.$currencyTrigger = this.shadowRoot.querySelector("#currency-trigger")
+        this.$currencyIcon = this.shadowRoot.querySelector("#currency-icon")
+        this.$currencyName = this.shadowRoot.querySelector("#currency-name")
+        this.$currencyModal = this.shadowRoot.querySelector("#currency-modal")
+        this.$currencyList = this.shadowRoot.querySelector("#currency-list")
         this.$chainTrigger = this.shadowRoot.querySelector("#chain-trigger")
         this.$chainIcon = this.shadowRoot.querySelector("#chain-icon")
         this.$chainName = this.shadowRoot.querySelector("#chain-name")
@@ -69,6 +82,7 @@ export class WALLETS extends HTMLElement {
         this.$labelWrap = this.shadowRoot.querySelector("#label-wrap")
         this.$labelInput = this.shadowRoot.querySelector("#label-input")
         this.$labelConfirm = this.shadowRoot.querySelector("#label-confirm")
+        this.$labelEdit = this.shadowRoot.querySelector("#label-edit")
         this.$walletPreviewActions = this.shadowRoot.querySelector("#wallet-preview-actions")
         this.$walletRemove = this.shadowRoot.querySelector("#wallet-remove")
         this.$walletSwitch = this.shadowRoot.querySelector("#wallet-switch")
@@ -127,12 +141,16 @@ export class WALLETS extends HTMLElement {
         // ── Preview action buttons ────────────────────────────────
         this.$walletSwitch.addEventListener("click", () => this._commitWallet(this._previewId))
         this.$walletRemove.addEventListener("click", () => this._promptDeleteWallet())
+        this.$labelEdit.addEventListener("click", () => this.$labelInput.focus())
 
         // ── Delete confirm modal ──────────────────────────────────
         this.$deleteConfirm.addEventListener("click", () => {
             this.$deleteModal.close()
             this._removeWallet()
         })
+
+        // ── Currency trigger opens the modal ──────────────────────
+        this.$currencyTrigger.addEventListener("click", () => this.$currencyModal.showModal())
 
         // ── Chain trigger opens the modal ─────────────────────────
         this.$chainTrigger.addEventListener("click", () => this.$chainModal.showModal())
@@ -163,37 +181,28 @@ export class WALLETS extends HTMLElement {
         if (this.dataset.currency === "false") {
             // Swap route: show all chains, no currency selector
             chains = Object.values(Chains).map((c) => ({
-                label: html`
-                    <ui-svg class="icon" data-src="/images/cryptos/${c.configs?.symbol || ""}" />
-                    ${c.configs?.name || c.id}
-                `,
                 value: c.id,
                 _name: c.configs?.name || c.id,
-                _symbol: c.configs?.symbol || ""
+                _symbol: c.configs?.symbol || "",
+                _standard: TOKEN_STANDARD[Number(c.id)] || null
             }))
-            chain = this.states.get("chain") || chains[0]?.value || null
+            chain = this.states.get("chain") || null
             this.states.set({ chain })
         } else {
-            // Deposit/withdraw: currency selector + filtered chains
-            currency = this.states.get("currency") || this.currencies[0]?.value || null
+            // Deposit/withdraw: no default — user must select coin and network
+            currency = this.states.get("currency") || null
             chains = this.chains(currency)
-            chain = chains.some((o) => o.value === this.states.get("chain")) ? this.states.get("chain") : chains[0]?.value || null
-            this.states.set({ currency: currency, chain: chain })
+            chain = chains.some((o) => o.value === this.states.get("chain")) ? this.states.get("chain") : null
+            this.states.set({ currency, chain })
         }
 
         // ── Build chain modal list and sync the trigger button ─────
         this._buildChainModal(chains)
 
-        // ── Currency select (deposit/withdraw only) ────────────────
+        // ── Currency modal (deposit/withdraw only) ────────────────
         if (this.dataset.currency !== "false") {
-            this.$currencies = new SELECT({
-                name: "currency",
-                options: this.currencies,
-                placeholder: "dictionary.currency",
-                selected: currency,
-                change: this.change
-            })
-            render(this.$currencies, this.shadowRoot.querySelector("#currencies"), { append: true })
+            this.$currencyTrigger.setAttribute("data-visible", "")
+            this._buildCurrencyModal(this.currencies, currency)
         }
 
         this.$identicons.addDisabled = this.total >= 20
@@ -219,6 +228,8 @@ export class WALLETS extends HTMLElement {
                 const options = this.chains(value)
                 const chain = options.some((o) => o.value === this.states.get("chain")) ? this.states.get("chain") : options[0]?.value || null
                 this._buildChainModal(options)
+                this._updateCurrencyTrigger(value)
+                this._updateCurrencyListSelection(value)
                 this.states.set({ currency: value, chain })
             } else {
                 this.states.set({ [name]: value })
@@ -272,8 +283,12 @@ export class WALLETS extends HTMLElement {
             const { raw } = await logic.balance({ wallet, currency, fiat, forex: Lives.forex, address })
             if (raw !== null) {
                 const locale = Context.get("locale")?.code || "en"
-                this.$balance.textContent = formatBalance(raw, locale)
+                const formatted = formatBalance(raw, locale)
+                this.$balance.textContent = formatted
                 this.$balanceSymbol.textContent = currency.symbol || ""
+                this.states.set({ balance: formatted })
+            } else {
+                this.states.set({ balance: null })
             }
         }
     }
@@ -282,10 +297,6 @@ export class WALLETS extends HTMLElement {
 
     get currencies() {
         return logic.currencies(Chains).map((c) => ({
-            label: html`
-                <ui-svg class="icon" data-src="/images/cryptos/${c.symbol}" />
-                ${c.name}
-            `,
             value: c.name,
             _name: c.name,
             _symbol: c.symbol
@@ -294,13 +305,10 @@ export class WALLETS extends HTMLElement {
 
     chains(currency = null) {
         return logic.chains(Chains, currency).map((c) => ({
-            label: html`
-                <ui-svg class="icon" data-src="/images/cryptos/${c.symbol}" />
-                ${c.name}
-            `,
             value: c.id,
             _name: c.name,
-            _symbol: c.symbol
+            _symbol: c.symbol,
+            _standard: TOKEN_STANDARD[Number(c.id)] || null
         }))
     }
 
@@ -313,6 +321,7 @@ export class WALLETS extends HTMLElement {
         this.$identicons.id = id
         this.$identicons.previewId = id
         this.$walletPreviewActions.hidden = false
+        this.$labelEdit.hidden = true
         this.$walletSwitch.hidden = editing
         this.$walletRemove.hidden = id !== this.total - 1
         this.$labelInput.disabled = true
@@ -329,7 +338,8 @@ export class WALLETS extends HTMLElement {
         this._previewId = null
         this.$identicons.id = this.id
         this.$identicons.previewId = null
-        this.$walletPreviewActions.hidden = !editing
+        this.$walletPreviewActions.hidden = false
+        this.$labelEdit.hidden = editing
         this.$walletRemove.hidden = true
         this.$walletSwitch.hidden = true
         this.$labelInput.disabled = false
@@ -346,9 +356,10 @@ export class WALLETS extends HTMLElement {
         this.$identicons.savedId = id
         this._previewId = null
         this.$identicons.previewId = null
-        this.$walletPreviewActions.hidden = true
+        this.$walletPreviewActions.hidden = false
+        this.$labelEdit.hidden = false
         this.$walletRemove.hidden = true
-        this.$walletSwitch.hidden = false
+        this.$walletSwitch.hidden = true
         this.$labelInput.disabled = false
         this.$identicons.flashSelected()
         this.change()
@@ -425,6 +436,7 @@ export class WALLETS extends HTMLElement {
         this.$labelInput.placeholder = Context.get(["dictionary", "walletName"]) || "Name this wallet"
 
         const showConfirm = () => {
+            this.$labelEdit.hidden = true
             this.$walletSwitch.hidden = true
             this.$labelConfirm.hidden = false
             this.$walletPreviewActions.hidden = false
@@ -435,11 +447,13 @@ export class WALLETS extends HTMLElement {
             this.$labelWrap.classList.remove("editing")
             // Restore preview-actions visibility to match current preview state
             if (this._previewId !== null) {
+                this.$labelEdit.hidden = true
                 this.$walletSwitch.hidden = false
                 this.$walletRemove.hidden = this._previewId !== this.total - 1
                 this.$walletPreviewActions.hidden = false
             } else {
-                this.$walletPreviewActions.hidden = true
+                this.$labelEdit.hidden = false
+                this.$walletPreviewActions.hidden = false
             }
         }
 
@@ -521,6 +535,13 @@ export class WALLETS extends HTMLElement {
 
             li.append(icon, name)
 
+            if (opt._standard) {
+                const std = document.createElement("span")
+                std.className = "chain-standard"
+                std.textContent = opt._standard
+                li.append(std)
+            }
+
             // Clicking a row selects the chain and closes the modal
             li.addEventListener("click", () => {
                 this.$chainModal.close()
@@ -542,7 +563,10 @@ export class WALLETS extends HTMLElement {
     _updateChainTrigger(chainId) {
         const opt = this._chainOptions?.find((o) => o.value === chainId)
         if (this.$chainIcon) this.$chainIcon.dataset.src = opt?._symbol ? `/images/cryptos/${opt._symbol}` : ""
-        if (this.$chainName) this.$chainName.textContent = opt?._name || opt?.value || ""
+        if (this.$chainName) {
+            const std = opt?._standard ? ` (${opt._standard})` : ""
+            this.$chainName.textContent = opt ? `${opt._name || opt.value}${std}` : ""
+        }
         this.$chainTrigger?.toggleAttribute("data-has-value", !!opt)
     }
 
@@ -553,6 +577,53 @@ export class WALLETS extends HTMLElement {
     _updateChainListSelection(chainId) {
         this.$chainList?.querySelectorAll("li").forEach((li) => {
             li.dataset.selected = li.dataset.value === chainId ? "true" : "false"
+        })
+    }
+
+    // ── Currency modal helpers ────────────────────────────────────
+
+    /**
+     * Populate the currency picker modal and sync the trigger button.
+     * Mirrors _buildChainModal exactly.
+     */
+    _buildCurrencyModal(options, selectedValue) {
+        this._currencyOptions = options
+        this.$currencyList.innerHTML = ""
+
+        for (const opt of options) {
+            const li = document.createElement("li")
+            li.dataset.value = opt.value
+
+            const icon = document.createElement("ui-svg")
+            if (opt._symbol) icon.dataset.src = `/images/cryptos/${opt._symbol}`
+
+            const name = document.createElement("span")
+            name.textContent = opt._name || opt.value
+
+            li.append(icon, name)
+
+            li.addEventListener("click", () => {
+                this.$currencyModal.close()
+                this.change({ target: { name: "currency", value: opt.value } })
+            })
+
+            this.$currencyList.append(li)
+        }
+
+        this._updateCurrencyTrigger(selectedValue)
+        this._updateCurrencyListSelection(selectedValue)
+    }
+
+    _updateCurrencyTrigger(currencyName) {
+        const opt = this._currencyOptions?.find((o) => o.value === currencyName)
+        if (this.$currencyIcon) this.$currencyIcon.dataset.src = opt?._symbol ? `/images/cryptos/${opt._symbol}` : ""
+        if (this.$currencyName) this.$currencyName.textContent = opt?._name || opt?.value || ""
+        this.$currencyTrigger?.toggleAttribute("data-has-value", !!opt)
+    }
+
+    _updateCurrencyListSelection(currencyName) {
+        this.$currencyList?.querySelectorAll("li").forEach((li) => {
+            li.dataset.selected = li.dataset.value === currencyName ? "true" : "false"
         })
     }
 

--- a/src/UI/components/wallets/styles.css.js
+++ b/src/UI/components/wallets/styles.css.js
@@ -24,6 +24,8 @@ export const styles = css`
         --identicons-pad-v: var(--space-4);
         /* Hide the #N number indicator — wallet names replace it */
         --identicons-status-left-display: none;
+        /* Allow the status-right (which holds the actions slot) to stretch full width */
+        --identicons-status-right-flex: 1;
     }
 
     /* ── Wallet actions slot ─────────────────────────────────────────────────────
@@ -79,13 +81,13 @@ export const styles = css`
         font-size: var(--text-sm);
         letter-spacing: 0.08em;
         text-transform: uppercase;
-        color: var(--accent-action);
+        color: var(--accent-info);
         background: transparent;
         border: none;
         border-bottom: 1px solid transparent;
         outline: none;
         padding: 0 0 1px;
-        caret-color: var(--accent-action);
+        caret-color: var(--accent-info);
         pointer-events: all;
         transition:
             border-bottom-color var(--speed),
@@ -100,12 +102,12 @@ export const styles = css`
         }
 
         &:hover {
-            border-bottom-color: color-mix(in hsl, var(--accent-action) 30%, transparent);
+            border-bottom-color: color-mix(in hsl, var(--accent-info) 30%, transparent);
         }
 
         &:focus {
-            border-bottom-color: var(--accent-action);
-            box-shadow: 0 1px 0 0 color-mix(in hsl, var(--accent-action) 40%, transparent);
+            border-bottom-color: var(--accent-info);
+            box-shadow: 0 1px 0 0 color-mix(in hsl, var(--accent-info) 40%, transparent);
         }
 
         &:disabled {
@@ -176,6 +178,42 @@ export const styles = css`
         align-items: center;
         flex-shrink: 0;
         margin-left: auto;
+    }
+
+    #label-edit {
+        display: inline-flex;
+        align-items: center;
+        justify-content: right;
+        flex-shrink: 0;
+        min-width: 2.25rem;
+        min-height: 2.25rem;
+        padding: 0;
+        background: none;
+        border: none;
+        cursor: pointer;
+        pointer-events: all;
+        outline: none;
+        color: var(--neon-g);
+        opacity: 0.35;
+        transition:
+            opacity var(--speed),
+            filter var(--speed);
+
+        ui-svg {
+            width: var(--icon-sm);
+            height: var(--icon-sm);
+            pointer-events: none;
+            --svg-color: currentColor;
+        }
+
+        &:hover {
+            opacity: 1;
+            filter: drop-shadow(0 0 4px color-mix(in hsl, var(--neon-g) 60%, transparent));
+        }
+
+        &:active {
+            opacity: 0.5;
+        }
 
         &[hidden] {
             display: none;
@@ -285,21 +323,45 @@ export const styles = css`
         }
     }
 
-    /* ── Merged wallet info row ─────────────────────────────────────────────────
-       Two stacked lines: address row on top, chain selector below.
-       Splitting avoids the chain pill squeezing out the address when the
-       chain name is long (e.g. "Binance Smart Chain Testnet").
-       ────────────────────────────────────────────────────────────────────────── */
+    /* ── Selector rows — label above, trigger below at 80% width ───────────────── */
+    #currency-row,
+    #chain-row {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--space-1);
+        padding: 0 var(--space);
+        margin-bottom: var(--space-3);
+    }
+
+    #currency-label,
+    #chain-label {
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color);
+        opacity: 0.4;
+        white-space: nowrap;
+    }
+
+    /* ── Address/balance card ────────────────────────────────────────────────── */
     #wallet-row {
         display: flex;
         flex-direction: column;
         gap: 0;
         padding: 0;
         background: var(--field-bg);
-        transition: background var(--speed);
+        box-shadow: 0 0 8px var(--accent-info-glow);
+        transition:
+            background var(--speed),
+            border-color var(--speed),
+            box-shadow var(--speed);
 
         &:focus-within {
             background: var(--field-bg-focus);
+            border-color: var(--accent-info);
+            box-shadow: 0 0 16px var(--accent-info-border);
         }
     }
 
@@ -308,7 +370,7 @@ export const styles = css`
        Grid guarantees an exact midpoint regardless of content length.
        ────────────────────────────────────────────────────────────────────────── */
     #address-wrap {
-        display: grid;
+        display: var(--wallet-address-wrap-display, grid);
         grid-template-columns: 1fr 1px 1fr;
         align-items: center;
         width: 100%;
@@ -424,11 +486,7 @@ export const styles = css`
         }
     }
 
-    /* ── Chain trigger pill ─────────────────────────────────────────────────────
-       Full-width row below the address — always has room for any chain name.
-       Resting border glows cyan at low opacity to signal it is the primary
-       selector; hover steps the glow up.
-       ────────────────────────────────────────────────────────────────────────── */
+    /* ── Chain trigger rows ──────────────────────────────────────────────────── */
     .chain-trigger {
         position: relative;
         display: flex;
@@ -437,9 +495,7 @@ export const styles = css`
         width: 100%;
         padding: var(--space-sm) var(--space);
         background: transparent;
-        /* Resting glow: signals this is a clickable selector */
-        border: 1px solid color-mix(in hsl, var(--accent-info) 35%, transparent);
-        box-shadow: 0 0 8px color-mix(in hsl, var(--accent-info) 12%, transparent);
+        border: none;
         box-sizing: border-box;
         color: var(--color);
         font-family: var(--header-font);
@@ -449,9 +505,8 @@ export const styles = css`
         cursor: pointer;
         outline: none;
         transition:
-            border-color var(--speed),
             color var(--speed),
-            box-shadow var(--speed);
+            background var(--speed);
 
         /* Chevron — pushed to the right end */
         &::after {
@@ -468,32 +523,42 @@ export const styles = css`
             mask-size: 10px 6px;
             -webkit-mask-repeat: no-repeat;
             mask-repeat: no-repeat;
-            opacity: 0.45;
+            opacity: 0.35;
             transition: opacity var(--speed);
         }
 
-        /* Hover: full cyan border + stronger glow */
         &:hover {
-            border-color: var(--accent-info);
             color: var(--accent-info);
-            box-shadow: 0 0 16px color-mix(in hsl, var(--accent-info) 35%, transparent);
+            background: color-mix(in hsl, var(--accent-info) 5%, transparent);
             &::after {
                 opacity: 1;
+            }
+            &::before {
+                opacity: 0.6;
             }
         }
 
         &:focus-visible {
-            border-color: var(--accent-info);
             color: var(--accent-info);
-            box-shadow: 0 0 16px color-mix(in hsl, var(--accent-info) 35%, transparent);
+            background: color-mix(in hsl, var(--accent-info) 5%, transparent);
         }
 
-        /* Active: collapse back to resting glow */
         &:active {
-            box-shadow: 0 0 8px color-mix(in hsl, var(--accent-info) 12%, transparent);
+            background: color-mix(in hsl, var(--accent-info) 8%, transparent);
         }
 
-        /* Chain icon — same sizing as swap-form trigger-icon */
+        /* Content area — fills remaining space, never wraps */
+        .trigger-body {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: var(--space-2);
+            min-width: 0;
+            overflow: hidden;
+        }
+
+        /* Chain icon */
         .trigger-icon {
             width: var(--icon-sm);
             height: var(--icon-sm);
@@ -501,19 +566,110 @@ export const styles = css`
             flex-shrink: 0;
         }
 
+        /* Selected value — accent color so it reads distinct from the dim prefix */
+        .trigger-value {
+            text-shadow: var(--glow-info);
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
         .trigger-placeholder {
             opacity: 0.45;
         }
 
-        /* Hide placeholder once a chain is selected */
+        /* Hide placeholder once a value is selected */
         &[data-has-value] .trigger-placeholder {
             display: none;
         }
 
         /* Hide icon + name until a value is set */
         &:not([data-has-value]) .trigger-icon,
-        &:not([data-has-value]) #chain-name {
+        &:not([data-has-value]) #chain-name,
+        &:not([data-has-value]) #currency-name {
             display: none;
+        }
+    }
+
+    /* ── Currency trigger — only shown in deposit/withdraw mode ────────────────
+       Hidden by default; JS shows it when dataset.currency !== "false".
+       ────────────────────────────────────────────────────────────────────────── */
+    #currency-trigger {
+        display: none;
+        border: 1px solid var(--accent-info-border);
+        box-shadow: 0 0 8px var(--accent-info-glow);
+
+        &[data-visible] {
+            display: flex;
+        }
+
+        &:hover {
+            border-color: var(--accent-info);
+            box-shadow: 0 0 16px var(--accent-info-border);
+        }
+    }
+
+    #chain-trigger {
+        align-items: center;
+        border: 1px solid var(--accent-info-border);
+        box-shadow: 0 0 8px var(--accent-info-glow);
+
+        &:hover {
+            border-color: var(--accent-info);
+            box-shadow: 0 0 16px var(--accent-info-border);
+        }
+
+        .trigger-icon {
+            align-self: center;
+        }
+    }
+
+    /* ── Currency picker modal list ─────────────────────────────────────────────
+       Mirrors #chain-list exactly.
+       ────────────────────────────────────────────────────────────────────────── */
+    #currency-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        min-width: 14rem;
+
+        li {
+            display: flex;
+            align-items: center;
+            gap: var(--space-sm);
+            padding: var(--space-sm) var(--space);
+            cursor: pointer;
+            font-family: var(--header-font);
+            font-size: var(--text-sm);
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: var(--color);
+            border-bottom: 1px solid color-mix(in hsl, var(--color) 8%, transparent);
+            transition:
+                background var(--speed),
+                color var(--speed);
+
+            &:last-child {
+                border-bottom: none;
+            }
+
+            &:hover {
+                background: var(--accent-info-surface);
+                color: var(--accent-info);
+            }
+
+            &[data-selected="true"] {
+                color: var(--accent-action);
+                background: color-mix(in hsl, var(--accent-action) 6%, transparent);
+                text-shadow: var(--glow-action);
+            }
+
+            ui-svg {
+                width: var(--icon-sm);
+                height: var(--icon-sm);
+                flex-shrink: 0;
+            }
         }
     }
 
@@ -572,30 +728,6 @@ export const styles = css`
         }
     }
 
-    /* ── Currency selector (deposit/withdraw routes only) ───────────────────────
-       Wrapped in field-bg when populated; ui-select stays borderless via
-       CSS custom property overrides.
-       ────────────────────────────────────────────────────────────────────────── */
-    #currencies {
-        &:empty {
-            display: none;
-        }
-
-        &:not(:empty) {
-            background: var(--field-bg);
-        }
-
-        ui-select {
-            --select-width: stretch;
-            --select-radius: 0;
-            --select-border: none;
-            --select-bg: transparent;
-            --select-bg-hover: color-mix(in hsl, var(--neon-g) 6%, transparent);
-            --select-border-hover: none;
-            --select-border-focus: none;
-        }
-    }
-
     /* ── Chain picker modal list ────────────────────────────────────────────────
        Flat rows: icon + chain name. Active chain highlighted green;
        hover previews in cyan — consistent with the rest of the UI.
@@ -627,7 +759,7 @@ export const styles = css`
             }
 
             &:hover {
-                background: color-mix(in hsl, var(--accent-info) 8%, transparent);
+                background: var(--accent-info-surface);
                 color: var(--accent-info);
             }
 
@@ -641,6 +773,14 @@ export const styles = css`
             ui-svg {
                 width: var(--icon-sm);
                 height: var(--icon-sm);
+                flex-shrink: 0;
+            }
+
+            .chain-standard {
+                margin-left: auto;
+                font-size: var(--text-xs);
+                letter-spacing: 0.08em;
+                opacity: 0.5;
                 flex-shrink: 0;
             }
         }

--- a/src/UI/components/wallets/template.js
+++ b/src/UI/components/wallets/template.js
@@ -28,11 +28,14 @@ export const template = html`
                  • Preview:  DELETE + SWAP
                  • Editing:  DELETE (if preview) + SAVE (replaces SWAP position)
             -->
-            <span id="wallet-preview-actions" hidden>
+            <span id="wallet-preview-actions">
                 <button id="wallet-remove" aria-label="Delete wallet" hidden>
                     <ui-svg data-src="/images/icons/trash.svg" />
                 </button>
-                <button id="wallet-switch" aria-label="Switch to wallet">
+                <button id="label-edit" aria-label="Edit wallet name">
+                    <ui-svg data-src="/images/icons/pencil.svg" />
+                </button>
+                <button id="wallet-switch" aria-label="Switch to wallet" hidden>
                     <ui-svg data-src="/images/icons/arrow-left-right.svg" />
                 </button>
                 <button id="label-confirm" aria-label="Save wallet name" hidden>
@@ -41,6 +44,28 @@ export const template = html`
             </span>
         </span>
     </ui-identicons>
+
+    <div id="currency-row">
+        <span id="currency-label"><ui-context data-key="dictionary.coin" /></span>
+        <button class="chain-trigger" id="currency-trigger">
+            <span class="trigger-body">
+                <ui-svg class="trigger-icon" id="currency-icon"></ui-svg>
+                <span class="trigger-placeholder"><ui-context data-key="dictionary.selectCoin" /></span>
+                <span class="trigger-value" id="currency-name"></span>
+            </span>
+        </button>
+    </div>
+
+    <div id="chain-row">
+        <span id="chain-label"><ui-context data-key="dictionary.network" /></span>
+        <button class="chain-trigger" id="chain-trigger">
+            <span class="trigger-body">
+                <ui-svg class="trigger-icon" id="chain-icon"></ui-svg>
+                <span class="trigger-placeholder"><ui-context data-key="dictionary.selectNetwork" /></span>
+                <span class="trigger-value" id="chain-name"></span>
+            </span>
+        </button>
+    </div>
 
     <div id="wallet-row">
         <div id="address-wrap">
@@ -57,15 +82,12 @@ export const template = html`
                 <span id="balance-symbol" class="balance-symbol"></span>
             </span>
         </div>
-        <button class="chain-trigger" id="chain-trigger">
-            <ui-svg class="trigger-icon" id="chain-icon"></ui-svg>
-            <span class="trigger-placeholder"><ui-context data-key="dictionary.chain" /></span>
-            <span class="trigger-value" id="chain-name"></span>
-        </button>
     </div>
 
-    <!-- ── Currency selector (deposit/withdraw routes only) ── -->
-    <div id="currencies"></div>
+    <!-- ── Currency picker modal (deposit/withdraw routes only) ── -->
+    <ui-modal id="currency-modal" data-header="currency">
+        <ul id="currency-list"></ul>
+    </ui-modal>
 
     <!-- ── Chain picker modal ── -->
     <ui-modal id="chain-modal" data-header="chain">

--- a/src/UI/css/elements/select.css.js
+++ b/src/UI/css/elements/select.css.js
@@ -86,8 +86,8 @@ export const styles = css`
                 color: var(--color);
             }
             option:checked {
-                background: color-mix(in srgb, var(--color-accent) 12%, transparent);
-                color: var(--color-accent);
+                background: var(--select-option-checked-bg, color-mix(in srgb, var(--color-accent) 12%, transparent));
+                color: var(--select-option-checked-color, var(--color-accent));
             }
             selectedcontent {
                 padding: 0;

--- a/src/UI/css/vars.css.js
+++ b/src/UI/css/vars.css.js
@@ -141,6 +141,7 @@ export const styles = css`
         --glow-c: 0 0 8px #00e5ff88, 0 0 24px #00e5ff33;
         --glow-m: 0 0 8px #ff2d7888, 0 0 24px #ff2d7833;
         --glow-y: 0 0 8px #f5e64288, 0 0 24px #f5e64233;
+        --glow-y: 0 0 8px #f5e64288, 0 0 24px #f5e64233;
 
         /* Layout hooks */
         --header-backdrop: blur(12px);
@@ -181,10 +182,31 @@ export const styles = css`
         /* Semantic interactive accents */
         --accent-info: var(--neon-c);       /* filters, search, links, info states */
         --accent-action: var(--neon-g);     /* confirm, submit, price, positive */
-        --accent-danger: var(--neon-m);     /* error, destructive, warning */
+        --accent-success: var(--neon-g);    /* success states, completed actions */
+        --accent-warning: var(--neon-y);    /* caution, irreversible actions, pre-error */
+        --accent-danger: var(--neon-m);     /* error, destructive, blocked */
         --glow-info: var(--glow-c);
         --glow-action: var(--glow-g);
+        --glow-success: var(--glow-g);
+        --glow-warning: var(--glow-y);
         --glow-danger: var(--glow-m);
+
+        /* Interactive surface tokens — resting border, glow shadow, hover/selected fill */
+        --accent-info-border:       color-mix(in hsl, var(--accent-info)    35%, transparent);
+        --accent-info-glow:         color-mix(in hsl, var(--accent-info)    12%, transparent);
+        --accent-info-surface:      color-mix(in hsl, var(--accent-info)     8%, transparent);
+        --accent-action-border:     color-mix(in hsl, var(--accent-action)  50%, transparent);
+        --accent-action-glow:       color-mix(in hsl, var(--accent-action)  20%, transparent);
+        --accent-action-surface:    color-mix(in hsl, var(--accent-action)  12%, transparent);
+        --accent-success-border:    color-mix(in hsl, var(--accent-success) 50%, transparent);
+        --accent-success-glow:      color-mix(in hsl, var(--accent-success) 20%, transparent);
+        --accent-success-surface:   color-mix(in hsl, var(--accent-success) 12%, transparent);
+        --accent-warning-border:    color-mix(in hsl, var(--accent-warning) 40%, transparent);
+        --accent-warning-glow:      color-mix(in hsl, var(--accent-warning) 15%, transparent);
+        --accent-warning-surface:   color-mix(in hsl, var(--accent-warning) 10%, transparent);
+        --accent-danger-border:     color-mix(in hsl, var(--accent-danger)  35%, transparent);
+        --accent-danger-glow:       color-mix(in hsl, var(--accent-danger)  12%, transparent);
+        --accent-danger-surface:    color-mix(in hsl, var(--accent-danger)   8%, transparent);
 
         /* Item cards */
         --item-border-left: 3px solid var(--neon-c);

--- a/src/UI/routes/deposit/index.js
+++ b/src/UI/routes/deposit/index.js
@@ -1,24 +1,284 @@
+/* eslint-disable curly */
 import template from "./template.js"
 import Route from "/core/UI/Route.js"
-import { Elements } from "/core/Stores.js"
+import { Access } from "/core/Access.js"
+import { render, html } from "/core/UI.js"
+import { Chains, Elements } from "/core/Stores.js"
+import { Context } from "/core/Context.js"
+import { notify } from "/core/Utils.js"
+import { sha256 } from "/core/Utils/crypto.js"
+import Logic from "/UI/components/wallets/logic.js"
+
+const TOKEN_STANDARD = {
+    1: "ERC20", // Ethereum
+    11155111: "ERC20", // Sepolia
+    56: "BEP20", // BSC
+    97: "BEP20" // BSC Testnet
+}
 
 export class DEPOSIT extends Route {
     static module = import.meta.url
+
     constructor() {
         super(template)
+        this._currency = null
+        this._chain = null
+        this._address = null
+        this._currencyOptions = []
+        this._chainOptions = []
     }
 
     async onconnect() {
-        this.$wallets = this.shadowRoot.querySelector("ui-wallets")
-        this.watch(this.$wallets.states, "address", async ({ value }) => {
-            const $qr = this.shadowRoot.querySelector("ui-qr")
-            if (!value) return
-            $qr.dataset.value = value
-        }, true)
+        // ── DOM refs ──────────────────────────────────────────────
+        this.$selection = this.shadowRoot.querySelector("#selection")
+        this.$coinBadge = this.shadowRoot.querySelector("#coin-badge")
+        this.$coinIcon = this.shadowRoot.querySelector("#coin-icon")
+        this.$coinName = this.shadowRoot.querySelector("#coin-name")
+        this.$chainBadge = this.shadowRoot.querySelector("#chain-badge")
+        this.$chainIcon = this.shadowRoot.querySelector("#chain-icon")
+        this.$chainName = this.shadowRoot.querySelector("#chain-name")
+        this.$coinModal = this.shadowRoot.querySelector("#coin-modal")
+        this.$coinList = this.shadowRoot.querySelector("#coin-list")
+        this.$chainModal = this.shadowRoot.querySelector("#chain-modal")
+        this.$chainList = this.shadowRoot.querySelector("#chain-list")
+        this.$qrWrap = this.shadowRoot.querySelector("#qr-section")
+        this.$qr = this.shadowRoot.querySelector("#qr")
+        this.$addressWrap = this.shadowRoot.querySelector("#address-wrap")
+        this.$addressBox = this.shadowRoot.querySelector("#address-box")
+        this.$address = this.shadowRoot.querySelector("#address")
+        this.$copyBtn = this.shadowRoot.querySelector("#copy-btn")
+
+        // ── Load currency contracts ───────────────────────────────
+        for (const chain of Object.values(Chains)) {
+            if (!chain.configs?.currencies?.length) continue
+            if (chain.configs.currencies.length !== Object.values(chain?.currencies).length) await chain.load()
+        }
+
+        // ── Build currency options ────────────────────────────────
+        this._currencyOptions = Logic.currencies(Chains).map((c) => ({
+            value: c.name,
+            _name: c.name,
+            _symbol: c.symbol
+        }))
+
+        // ── Seed from URL params ──────────────────────────────────
+        const params = Context.get("params") || {}
+        if (params.currency) {
+            const match = this._currencyOptions.find((o) => o.value === params.currency)
+            if (match) this._currency = match.value
+        }
+        if (params.chain) {
+            this._chain = params.chain
+        }
+
+        // ── Wire modals ───────────────────────────────────────────
+        this._renderCoinModal()
+        this.$coinModal.setRequired(true)
+        this.$coinBadge.addEventListener("click", () => this.$coinModal.showModal())
+        this.$chainBadge.addEventListener("click", () => {
+            if (!this._currency) return
+            this._renderChainModal(this._buildChainOptions(this._currency))
+            this.$chainModal.showModal()
+        })
+
+        // ── Copy on click anywhere in address box ─────────────────
+        this.$addressBox.addEventListener("click", async () => {
+            if (!this._address) return
+            await navigator.clipboard.writeText(this._address)
+            this.$copyBtn.classList.add("copied")
+            setTimeout(() => this.$copyBtn.classList.remove("copied"), 600)
+            notify({ content: Context.get(["dictionary", "copiedToClipboard"]), autoClose: true })
+        })
+
+        // ── Auth gate ─────────────────────────────────────────────
+        this.watch(Access, "authenticated", ({ value }) => {
+            if (value) this._refresh()
+            else this._clearAddress()
+        })
+
         Elements.Access?.checkpoint()
+
+        // ── Step sequencing on load ───────────────────────────────
+        if (this._currency && this._chain) {
+            // Both pre-filled from URL — go straight to address view
+            this._syncBadges()
+            if (Access.get("authenticated")) await this._refresh()
+        } else if (this._currency) {
+            // Coin known, prompt chain
+            this._syncBadges()
+            this._promptChain()
+        } else {
+            // Nothing known — prompt coin first
+            this.$coinModal.showModal()
+        }
+    }
+
+    // ── Step helpers ──────────────────────────────────────────────
+
+    _promptChain() {
+        const opts = this._buildChainOptions(this._currency)
+        this._chainOptions = opts
+        if (!opts.some((o) => o.value === this._chain)) this._chain = null
+        this._renderChainModal(opts, /* required */ !this._chain)
+        this.$chainModal.showModal()
+    }
+
+    // ── Coin modal ────────────────────────────────────────────────
+
+    _renderCoinModal() {
+        this.$coinList.innerHTML = ""
+        for (const opt of this._currencyOptions) {
+            const li = document.createElement("li")
+            li.dataset.value = opt.value
+            const icon = document.createElement("ui-svg")
+            if (opt._symbol) icon.dataset.src = `/images/cryptos/${opt._symbol}`
+            const name = document.createElement("span")
+            name.textContent = opt._name || opt.value
+            li.append(icon, name)
+            li.addEventListener("click", () => this._onCurrencyChange(opt.value))
+            this.$coinList.append(li)
+        }
+        this._updateCoinListSelection(this._currency)
+    }
+
+    _updateCoinListSelection(currency) {
+        this.$coinList?.querySelectorAll("li").forEach((li) => {
+            li.dataset.selected = li.dataset.value === currency ? "true" : "false"
+        })
+    }
+
+    _onCurrencyChange(currency) {
+        this.$coinModal.setRequired(false)
+        this.$coinModal.close()
+        this._currency = currency
+        this._updateCoinListSelection(currency)
+        this._clearAddress()
+        this._promptChain()
+        this._syncBadges()
+    }
+
+    // ── Chain modal ───────────────────────────────────────────────
+
+    _buildChainOptions(currency) {
+        return Logic.chains(Chains, currency).map((c) => ({
+            value: c.id,
+            _name: c.name,
+            _symbol: c.symbol,
+            _standard: TOKEN_STANDARD[c.id] || null
+        }))
+    }
+
+    _renderChainModal(options, required = false) {
+        this.$chainModal.setRequired(required)
+        this._chainOptions = options
+        this.$chainList.innerHTML = ""
+        for (const opt of options) {
+            const li = document.createElement("li")
+            li.dataset.value = opt.value
+            const icon = document.createElement("ui-svg")
+            if (opt._symbol) icon.dataset.src = `/images/cryptos/${opt._symbol}`
+            const name = document.createElement("span")
+            name.textContent = opt._name || opt.value
+            li.append(icon, name)
+            if (opt._standard) {
+                const std = document.createElement("span")
+                std.className = "chain-standard"
+                std.textContent = opt._standard
+                li.append(std)
+            }
+            li.addEventListener("click", () => this._onChainChange(opt.value))
+            this.$chainList.append(li)
+        }
+        this._updateChainListSelection(this._chain)
+    }
+
+    _updateChainListSelection(chainId) {
+        this.$chainList?.querySelectorAll("li").forEach((li) => {
+            li.dataset.selected = li.dataset.value === chainId ? "true" : "false"
+        })
+    }
+
+    _onChainChange(chainId) {
+        this.$chainModal.setRequired(false)
+        this.$chainModal.close()
+        this._chain = chainId
+        this._updateChainListSelection(chainId)
+        this._syncBadges()
+        if (Access.get("authenticated")) this._refresh()
+    }
+
+    // ── Badges ────────────────────────────────────────────────────
+
+    _syncBadges() {
+        const coin = this._currencyOptions.find((o) => o.value === this._currency)
+        const chain = this._chainOptions.find((o) => o.value === this._chain)
+
+        if (this.$coinIcon) this.$coinIcon.dataset.src = coin?._symbol ? `/images/cryptos/${coin._symbol}` : ""
+        if (this.$coinName) this.$coinName.textContent = coin?._name || coin?.value || ""
+        if (this.$chainIcon) this.$chainIcon.dataset.src = chain?._symbol ? `/images/cryptos/${chain._symbol}` : ""
+        if (this.$chainName) {
+            const std = chain?._standard ? ` (${chain._standard})` : ""
+            this.$chainName.textContent = chain ? `${chain._name || chain.value}${std}` : ""
+        }
+
+        this.$selection.hidden = !coin
+        this.$chainBadge.toggleAttribute("data-has-value", !!chain)
+        this.$chainBadge.toggleAttribute("data-empty", !chain)
+    }
+
+    // ── Address ───────────────────────────────────────────────────
+
+    async _refresh() {
+        const address = await this._deriveAddress()
+        this._address = address || null
+        this._showAddress(address)
+    }
+
+    async _deriveAddress() {
+        const priv = Access.get("pair")?.priv
+        const id = Number(Access.get("wallet")?.id || 0)
+        const chain = Chains[this._chain]
+        if (!priv || !chain) return null
+        try {
+            const seed = sha256(priv + id)
+            return chain.public(chain.private(seed)) || null
+        } catch {
+            return null
+        }
+    }
+
+    _showAddress(address) {
+        const hasAddress = !!address
+
+        // QR
+        this.$qrWrap.hidden = !hasAddress
+        if (hasAddress) this.$qr.dataset.value = address
+        else this.$qr.removeAttribute("data-value")
+
+        // Address with highlighted first-6 / last-6
+        this.$addressWrap.hidden = !hasAddress
+        if (address && this.$address) {
+            const pre = address.slice(0, 6)
+            const mid = address.slice(6, -6)
+            const post = address.slice(-6)
+            render(
+                html`
+                    <span class="addr-hi">${pre}</span>
+                    <span class="addr-mid">${mid}</span>
+                    <span class="addr-hi">${post}</span>
+                `,
+                this.$address
+            )
+        } else if (this.$address) {
+            this.$address.innerHTML = ""
+        }
+    }
+
+    _clearAddress() {
+        this._address = null
+        this._showAddress(null)
     }
 }
 
 customElements.define("route-deposit", DEPOSIT)
-
 export default DEPOSIT

--- a/src/UI/routes/deposit/styles.css.js
+++ b/src/UI/routes/deposit/styles.css.js
@@ -3,11 +3,385 @@ import { css } from "/core/UI.js"
 export const styles = css`
     :host {
         main {
+            width: 100%;
+            max-width: 100%;
+            padding-inline: 0;
+        }
+
+        ui-card {
+            width: 100%;
+        }
+    }
+
+    /* ── Card body wrapper ── */
+    #deposit-body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--space-5);
+        padding: var(--space-4) var(--space-4) var(--space-6);
+        width: 100%;
+        min-width: 0;
+        box-sizing: border-box;
+        align-self: stretch;
+    }
+
+    /* ── Selection badges ── */
+    #selection {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--space-3);
+        width: 100%;
+
+        &[hidden] {
+            display: none;
+        }
+    }
+
+    #selection-coin {
+        display: flex;
+        justify-content: center;
+    }
+
+    #selection-chain {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--space-1);
+        width: 100%;
+
+        #chain-badge {
+            width: 100%;
+            border-radius: var(--radius);
+            justify-content: flex-start;
+        }
+    }
+
+    #chain-warning {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--space-2);
+        margin: var(--space-1) 0 0;
+        padding: var(--space-2) var(--space-3);
+        background: var(--accent-warning-surface);
+        border: 1px solid var(--accent-warning-border);
+        border-radius: var(--radius);
+        font-size: var(--text-xs);
+        font-family: var(--content-font);
+        line-height: 1.5;
+        color: var(--accent-warning);
+        opacity: 0.85;
+        width: 100%;
+        box-sizing: border-box;
+
+        &::before {
+            content: "⚠";
+            flex-shrink: 0;
+            font-size: var(--text-sm);
+            line-height: 1.4;
+            opacity: 0.9;
+        }
+    }
+
+    .selection-label {
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color);
+        opacity: 0.4;
+        padding-left: var(--space-1);
+    }
+
+    .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: var(--space-2) var(--space-3);
+        background: color-mix(in hsl, var(--accent-info) 6%, transparent);
+        border: 1px solid color-mix(in hsl, var(--accent-info) 22%, transparent);
+        border-radius: var(--radius-pill);
+        color: var(--accent-info);
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        cursor: pointer;
+        outline: none;
+        box-shadow: 0 0 8px var(--accent-info-glow);
+        text-shadow: var(--glow-info);
+        transition:
+            border-color var(--speed),
+            color var(--speed),
+            background var(--speed),
+            box-shadow var(--speed);
+
+        &:hover {
+            border-color: color-mix(in hsl, var(--accent-info) 60%, transparent);
+            background: color-mix(in hsl, var(--accent-info) 12%, transparent);
+            box-shadow: 0 0 14px color-mix(in hsl, var(--accent-info) 25%, transparent);
+        }
+
+        &:focus-visible {
+            border-color: var(--accent-info);
+            box-shadow: var(--glow-info);
+        }
+
+        &:active {
+            opacity: 0.7;
+        }
+
+        &[data-empty] {
+            border-style: dashed;
+            opacity: 0.5;
+            box-shadow: none;
+            text-shadow: none;
+        }
+    }
+
+    .badge-icon,
+    .badge-chevron {
+        width: var(--icon-sm);
+        height: var(--icon-sm);
+        flex-shrink: 0;
+    }
+
+    .badge-chevron {
+        opacity: 0.45;
+        transition: opacity var(--speed), transform var(--speed);
+    }
+
+    #coin-badge:hover .badge-chevron {
+        opacity: 1;
+    }
+
+    #chain-badge .badge-chevron {
+        margin-left: auto;
+    }
+
+    #chain-badge:hover .badge-chevron {
+        opacity: 1;
+        transform: translateX(2px);
+    }
+
+    /* ── QR section ── */
+    #qr-section {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--space-3);
+        width: 100%;
+
+        &[hidden] {
+            display: none;
+        }
+    }
+
+    #scan-label {
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--accent-action);
+        text-shadow: var(--glow-action);
+        opacity: 0.75;
+        margin: 0;
+    }
+
+    /* Branded QR frame with corner accent marks */
+    #qr-frame {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: var(--space-3);
+
+        ui-qr {
+            display: block;
+            width: min(72vw, 260px);
+            height: min(72vw, 260px);
+        }
+    }
+
+    /* Glowing corner brackets */
+    #qr-corner {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+    }
+
+    .corner {
+        position: absolute;
+        width: 18px;
+        height: 18px;
+        border-color: var(--accent-action);
+        border-style: solid;
+        border-width: 0;
+        filter: drop-shadow(0 0 4px color-mix(in hsl, var(--accent-action) 70%, transparent));
+    }
+
+    .corner.tl {
+        top: 0;
+        left: 0;
+        border-top-width: 2px;
+        border-left-width: 2px;
+    }
+    .corner.tr {
+        top: 0;
+        right: 0;
+        border-top-width: 2px;
+        border-right-width: 2px;
+    }
+    .corner.bl {
+        bottom: 0;
+        left: 0;
+        border-bottom-width: 2px;
+        border-left-width: 2px;
+    }
+    .corner.br {
+        bottom: 0;
+        right: 0;
+        border-bottom-width: 2px;
+        border-right-width: 2px;
+    }
+
+    /* ── Address wrap ── */
+    #address-wrap {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--space-2);
+        width: 100%;
+
+        &[hidden] {
+            display: none;
+        }
+    }
+
+    /* Address pill container — full area is the copy target */
+    #address-box {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        padding: var(--space-2) var(--space-3);
+        background: color-mix(in hsl, var(--color) 5%, transparent);
+        border: 1px solid color-mix(in hsl, var(--color) 12%, transparent);
+        border-radius: var(--radius);
+        cursor: pointer;
+        transition:
+            border-color var(--speed),
+            background var(--speed);
+
+        &:hover {
+            background: color-mix(in hsl, var(--accent-info) 6%, transparent);
+            border-color: var(--accent-info-border);
+        }
+
+        &:active {
+            opacity: 0.8;
+        }
+    }
+
+    #address {
+        flex: 1;
+        font-family: monospace;
+        font-size: var(--text-md);
+        letter-spacing: 0.04em;
+        word-break: break-all;
+        line-height: 1.6;
+
+        .addr-hi {
+            color: var(--accent-info);
+            text-shadow: var(--glow-info);
+            font-weight: 600;
+        }
+
+        .addr-mid {
+            color: var(--color);
+            opacity: 0.45;
+        }
+    }
+
+    #copy-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        opacity: 0.4;
+        transition:
+            opacity var(--speed),
+            filter var(--speed);
+
+        ui-icon {
+            --background: transparent;
+            --background-inverted: transparent;
+            --color: var(--accent-action);
+            --color-inverted: var(--accent-action);
+            --icon: var(--icon-md);
+        }
+
+        &.copied {
+            opacity: 1;
+            filter: drop-shadow(0 0 4px color-mix(in hsl, var(--accent-action) 60%, transparent));
+        }
+    }
+
+    #address-box:hover #copy-btn {
+        opacity: 0.75;
+    }
+
+    /* ── Coin + Chain picker modal lists ── */
+    #coin-list,
+    #chain-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        min-width: 14rem;
+
+        li {
             display: flex;
-            align-self: center;
-            flex-direction: column;
-            gap: var(--space);
-            max-width: var(--box-width);
+            align-items: center;
+            gap: var(--space-sm);
+            padding: var(--space-sm) var(--space);
+            cursor: pointer;
+            font-family: var(--header-font);
+            font-size: var(--text-sm);
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: var(--color);
+            border-bottom: 1px solid color-mix(in hsl, var(--color) 8%, transparent);
+            transition:
+                background var(--speed),
+                color var(--speed);
+
+            &:last-child {
+                border-bottom: none;
+            }
+
+            &:hover {
+                background: var(--accent-info-surface);
+                color: var(--accent-info);
+            }
+
+            &[data-selected="true"] {
+                color: var(--accent-action);
+                background: color-mix(in hsl, var(--accent-action) 6%, transparent);
+                text-shadow: var(--glow-action);
+            }
+
+            ui-svg {
+                width: var(--icon-sm);
+                height: var(--icon-sm);
+                flex-shrink: 0;
+            }
+
+            .chain-standard {
+                margin-left: auto;
+                font-size: 0.8em;
+                opacity: 0.4;
+                letter-spacing: 0.04em;
+            }
         }
     }
 `

--- a/src/UI/routes/deposit/template.js
+++ b/src/UI/routes/deposit/template.js
@@ -1,18 +1,77 @@
 import { html } from "/core/UI.js"
 import "/UI/layouts/main/index.js"
-import "/UI/components/wallets/index.js"
 import "/UI/components/context/index.js"
 import "/UI/components/qr/index.js"
+import "/UI/components/svg/index.js"
+import "/UI/components/icon/index.js"
+import "/UI/components/card/index.js"
+import "/UI/components/modal/index.js"
 import styles from "./styles.css.js"
 
 export const template = html`
     ${styles}
     <layout-main>
-        <h1><ui-context data-key="dictionary.deposit" /></h1>
         <main>
-            <ui-wallets />
-            <ui-qr id="qr" />
+            <ui-card data-title="deposit">
+                <div id="deposit-body">
+                    <!-- ── Coin / Chain selection row ── -->
+                    <div id="selection" hidden>
+                        <div id="selection-coin">
+                            <button id="coin-badge" class="badge" aria-label="Change coin">
+                                <ui-svg id="coin-icon" class="badge-icon"></ui-svg>
+                                <span id="coin-name"></span>
+                                <ui-svg class="badge-chevron" data-src="/images/icons/chevron-down.svg"></ui-svg>
+                            </button>
+                        </div>
+                        <div id="selection-chain">
+                            <span class="selection-label"><ui-context data-key="dictionary.chain" /></span>
+                            <button id="chain-badge" class="badge" aria-label="Change network">
+                                <ui-svg id="chain-icon" class="badge-icon"></ui-svg>
+                                <span id="chain-name"></span>
+                                <ui-svg class="badge-chevron" data-src="/images/icons/chevron-down.svg"></ui-svg>
+                            </button>
+                            <p id="chain-warning">
+                                <ui-context data-key="dictionary.wrongChainWarning" />
+                            </p>
+                        </div>
+                    </div>
+
+                    <!-- ── QR section ── -->
+                    <div id="qr-section" hidden>
+                        <p id="scan-label"><ui-context data-key="dictionary.scanToDeposit" /></p>
+                        <div id="qr-frame">
+                            <div id="qr-corner" aria-hidden="true">
+                                <span class="corner tl"></span>
+                                <span class="corner tr"></span>
+                                <span class="corner bl"></span>
+                                <span class="corner br"></span>
+                            </div>
+                            <ui-qr id="qr" />
+                        </div>
+                    </div>
+
+                    <!-- ── Address ── -->
+                    <div id="address-wrap" hidden>
+                        <div id="address-box">
+                            <div id="address"></div>
+                            <span id="copy-btn" aria-hidden="true">
+                                <ui-icon data-icon="copy" />
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </ui-card>
         </main>
     </layout-main>
+
+    <!-- ── Coin picker modal ── -->
+    <ui-modal id="coin-modal" data-header="currency">
+        <ul id="coin-list"></ul>
+    </ui-modal>
+
+    <!-- ── Chain picker modal ── -->
+    <ui-modal id="chain-modal" data-header="chain">
+        <ul id="chain-list"></ul>
+    </ui-modal>
 `
 export default template

--- a/src/UI/routes/withdraw/index.js
+++ b/src/UI/routes/withdraw/index.js
@@ -1,91 +1,240 @@
+/* eslint-disable curly */
 import template from "./template.js"
+import Route from "/core/UI/Route.js"
+import { Access } from "/core/Access.js"
+import { Wallets, Chains } from "/core/Stores.js"
+
+const TOKEN_STANDARD = {
+    1: "ERC20", // Ethereum
+    11155111: "ERC20", // Sepolia
+    56: "BEP20", // BSC
+    97: "BEP20" // BSC Testnet
+}
 import { Context } from "/core/Context.js"
 import { notify } from "/core/Utils.js"
-import { Elements, Wallets } from "/core/Stores.js"
-import Route from "/core/UI/Route.js"
-import logic from "./logic.js"
+import SendLogic from "./logic.js"
 
 export class WITHDRAW extends Route {
     static module = import.meta.url
+
     constructor() {
         super(template)
-        this.submit = this.submit.bind(this)
         this.estimateGas = this.estimateGas.bind(this)
+        this.submit = this.submit.bind(this)
     }
 
-    onconnect() {
-        this.$wallets = this.shadowRoot.querySelector("ui-wallets")
+    async onconnect() {
+        // ── DOM refs ──────────────────────────────────────────────
+        this.$wallets = this.shadowRoot.querySelector("#wallets")
         this.$form = this.shadowRoot.querySelector("#form")
         this.$gas = this.shadowRoot.querySelector("#gas")
-        const $submit = this.shadowRoot.querySelector("#submit")
+        this.$submit = this.shadowRoot.querySelector("#submit")
+        this.$addressError = this.shadowRoot.querySelector("#address-error")
+        this.$amountSymbol = this.shadowRoot.querySelector("#amount-symbol")
+        this.$availableBalance = this.shadowRoot.querySelector("#available-balance")
+        this.$amountError = this.shadowRoot.querySelector("#amount-error")
+        this.$infoNetwork = this.shadowRoot.querySelector("#info-network-value")
+        this.$infoAddress = this.shadowRoot.querySelector("#info-address-value")
 
-        this.$form.querySelectorAll("input[type='text'], input[type='number']").forEach((input) => {
-            this.sub(Context.on(["dictionary", input.name], [input, "placeholder"]))
-            this.listen(input, "input", this.estimateGas)
+        // ── Form inputs ───────────────────────────────────────────
+        const $address = this.$form.querySelector("input[name='address']")
+        const $amount = this.$form.querySelector("input[name='amount']")
+
+        this.listen($address, "input", () => {
+            this._syncSubmit()
+            this.estimateGas()
+        })
+        this.listen($address, "blur", () => this._syncAddressError())
+        this.listen($address, "input", () => {
+            if (!$address.value.trim()) this._syncAddressError()
         })
 
-        this.listen($submit, "click", this.submit)
+        this.listen($amount, "input", () => {
+            this._syncAmountError()
+            this._syncSubmit()
+            this.estimateGas()
+        })
 
+        this.listen(this.$submit, "click", this.submit)
+
+        // ── Auth gate ─────────────────────────────────────────────
+        this.watch(Access, "authenticated", ({ value }) => {
+            this._syncSubmit()
+            if (!value) {
+                this.$form.reset()
+                this.$gas.removeAttribute("visible")
+                this.$gas.textContent = ""
+            }
+        })
+
+        // ── Wallets state changes ─────────────────────────────────
         this.sub(
-            this.$wallets.states.on("address", ({ value }) => {
-                this.$form.querySelectorAll("input").forEach((el) => (el.disabled = !value))
-                $submit.toggleAttribute("disabled", !value)
-                if (!value) {
-                    this.$form.reset()
-                    this.$gas.textContent = ""
-                } else 
-                    this.estimateGas()
-                
-            }, true)
+            this.$wallets.states.on("currency", () => {
+                this._syncAmountSymbol()
+                this._syncNetworkInfo()
+                this._syncFormVisibility()
+                this._syncSubmit()
+                this.estimateGas()
+            }),
+            this.$wallets.states.on("chain", () => {
+                this._syncNetworkInfo()
+                this._syncFormVisibility()
+                this._syncSubmit()
+                this.estimateGas()
+            }),
+            this.$wallets.states.on("address", () => {
+                this._syncNetworkInfo()
+            }),
+            this.$wallets.states.on("balance", () => {
+                this._syncAvailableBalance()
+                this._syncAmountError()
+            })
         )
 
-        Elements.Access?.checkpoint()
+        // ── Step sequencing on load ───────────────────────────────
+        // Wallets component seeds chain/currency from URL params on its own;
+        // run an initial sync once it has settled.
+        this._syncAmountSymbol()
+        this._syncAvailableBalance()
+        this._syncNetworkInfo()
+        this._syncFormVisibility()
+        this._syncSubmit()
     }
 
     ondisconnect() {
         clearTimeout(this.$gaspend)
     }
 
+    // ── Sync helpers ──────────────────────────────────────────────
+
+    _syncFormVisibility() {
+        const ready = !!(this.$wallets.states.get("currency") && this.$wallets.states.get("chain"))
+        this.$form.hidden = !ready
+        if (!ready) {
+            this.$form.reset()
+            this.$gas.removeAttribute("visible")
+            this.$gas.textContent = ""
+            if (this.$addressError) this.$addressError.removeAttribute("visible")
+            if (this.$amountError) this.$amountError.removeAttribute("visible")
+            if (this.$infoNetwork) this.$infoNetwork.textContent = "—"
+            if (this.$infoAddress) this.$infoAddress.textContent = "—"
+        }
+    }
+
+    _syncAmountSymbol() {
+        const currency = this.$wallets.states.get("currency")
+        if (this.$amountSymbol) this.$amountSymbol.textContent = currency || ""
+    }
+
+    _syncAmountError() {
+        if (!this.$amountError) return
+        const amount = Number(this.$form?.querySelector("input[name='amount']")?.value)
+        const balance = this.$wallets.states.get("balance")
+        const exceeded = amount > 0 && balance != null && amount > Number(balance.replace(/[^0-9.]/g, ""))
+        this.$amountError.toggleAttribute("visible", exceeded)
+    }
+
+    _syncNetworkInfo() {
+        const chainId = this.$wallets.states.get("chain")
+        const chain = Chains[chainId]
+        if (this.$infoNetwork) {
+            if (chain) {
+                const std = TOKEN_STANDARD[Number(chainId)]
+                this.$infoNetwork.textContent = std ? `${chain.configs?.name || chainId} (${std})` : chain.configs?.name || chainId
+            } else {
+                this.$infoNetwork.textContent = "—"
+            }
+        }
+        if (this.$infoAddress) {
+            const address = this.$wallets.states.get("address")
+            this.$infoAddress.textContent = address || "—"
+        }
+    }
+
+    _syncAvailableBalance() {
+        if (!this.$availableBalance) return
+        const balance = this.$wallets.states.get("balance")
+        const currency = this.$wallets.states.get("currency")
+        if (balance != null && currency) {
+            const label = Context.get(["dictionary", "available"]) || "Available"
+            this.$availableBalance.textContent = `${label}: ${balance} ${currency}`
+            this.$availableBalance.setAttribute("visible", "")
+        } else {
+            this.$availableBalance.removeAttribute("visible")
+            this.$availableBalance.textContent = ""
+        }
+    }
+
+    _syncSubmit() {
+        const amount = Number(this.$form?.querySelector("input[name='amount']")?.value)
+        const address = this.$form?.querySelector("input[name='address']")?.value?.trim()
+        const currency = this.$wallets.states.get("currency")
+        const chain = this.$wallets.states.get("chain")
+        const balance = this.$wallets.states.get("balance")
+        const exceeded = amount > 0 && balance != null && amount > Number(balance.replace(/[^0-9.]/g, ""))
+        const ready = !!(currency && chain && Access.get("authenticated") && amount > 0 && address && !exceeded)
+        this.$submit?.toggleAttribute("disabled", !ready)
+    }
+
+    _syncAddressError() {
+        const empty = !this.$form.querySelector("input[name='address']")?.value?.trim()
+        if (this.$addressError) this.$addressError.toggleAttribute("visible", empty)
+    }
+
+    // ── Gas estimate ──────────────────────────────────────────────
+
     estimateGas() {
         clearTimeout(this.$gaspend)
         this.$gaspend = setTimeout(async () => {
             const chain = this.$wallets.states.get("chain")
-            const fee = await logic.gas({
+            const currency = this.$wallets.states.get("currency")
+            const fee = await SendLogic.gas({
                 wallet: Wallets[chain],
-                name: this.$wallets.states.get("currency"),
+                name: currency,
                 to: this.$form.querySelector("input[name='address']").value,
-                amount: this.$form.querySelector("input[name='amount']").value,
+                amount: this.$form.querySelector("input[name='amount']").value
             })
-            if (!fee) { this.$gas.textContent = ""; return }
+            if (!fee) {
+                this.$gas.removeAttribute("visible")
+                this.$gas.textContent = ""
+                return
+            }
             const label = Context.get(["dictionary", "gasFee"])
             this.$gas.textContent = `${label}: ${fee.amount} ${fee.symbol}`
+            this.$gas.setAttribute("visible", "")
         }, 500)
     }
+
+    // ── Submit ────────────────────────────────────────────────────
 
     async submit() {
         const data = Object.fromEntries(new FormData(this.$form))
         const chain = this.$wallets.states.get("chain")
-        const name = this.$wallets.states.get("currency")
+        const currency = this.$wallets.states.get("currency")
 
-        if (!data.amount || !data.address || !chain || !name)
-            return notify({ content: Context.get(["dictionary", "missingRequiredFields"]), autoClose: true })
+        if (!data.amount || !data.address || !chain || !currency) return notify({ content: Context.get(["dictionary", "missingRequiredFields"]), autoClose: true })
 
         this.$form.querySelectorAll("input").forEach((el) => (el.disabled = true))
-        this.shadowRoot.querySelector("#submit").toggleAttribute("disabled", true)
+        this.$submit.toggleAttribute("disabled", true)
 
-        const result = await logic.send({ wallet: Wallets[chain], name, to: data.address, amount: data.amount })
+        const result = await SendLogic.send({
+            wallet: Wallets[chain],
+            name: currency,
+            to: data.address,
+            amount: data.amount
+        })
 
         this.$form.querySelectorAll("input").forEach((el) => (el.disabled = false))
-        this.shadowRoot.querySelector("#submit").toggleAttribute("disabled", false)
+        this.$submit.toggleAttribute("disabled", false)
 
         if (result.success) {
             notify({ content: Context.get(["dictionary", "transactionSent"]), autoClose: true })
             this.$form.reset()
-        } else
-            notify({ content: Context.get(["dictionary", result.error || "transactionError"]), autoClose: true })
+            this.$gas.removeAttribute("visible")
+            this.$gas.textContent = ""
+        } else notify({ content: Context.get(["dictionary", result.error || "transactionError"]), autoClose: true })
     }
 }
 
 customElements.define("route-withdraw", WITHDRAW)
-
 export default WITHDRAW

--- a/src/UI/routes/withdraw/index.js
+++ b/src/UI/routes/withdraw/index.js
@@ -26,6 +26,7 @@ export class WITHDRAW extends Route {
     async onconnect() {
         // ── DOM refs ──────────────────────────────────────────────
         this.$wallets = this.shadowRoot.querySelector("#wallets")
+        this.$withdrawCard = this.shadowRoot.querySelector("#withdraw-card")
         this.$form = this.shadowRoot.querySelector("#form")
         this.$gas = this.shadowRoot.querySelector("#gas")
         this.$submit = this.shadowRoot.querySelector("#submit")
@@ -37,16 +38,31 @@ export class WITHDRAW extends Route {
         this.$infoAddress = this.shadowRoot.querySelector("#info-address-value")
 
         // ── Form inputs ───────────────────────────────────────────
-        const $address = this.$form.querySelector("input[name='address']")
+        this.$addressDisplay = this.$form.querySelector("#address-display")
+        this.$addressHidden = this.$form.querySelector("#address-hidden")
         const $amount = this.$form.querySelector("input[name='amount']")
 
-        this.listen($address, "input", () => {
+        this.listen(this.$addressDisplay, "input", () => {
+            this._syncAddressValue()
             this._syncSubmit()
             this.estimateGas()
         })
-        this.listen($address, "blur", () => this._syncAddressError())
-        this.listen($address, "input", () => {
-            if (!$address.value.trim()) this._syncAddressError()
+        this.listen(this.$addressDisplay, "paste", (e) => {
+            e.preventDefault()
+            const text = (e.clipboardData || window.clipboardData).getData("text/plain").trim()
+            const sel = this.shadowRoot.getSelection?.() ?? window.getSelection()
+            if (sel && sel.rangeCount) {
+                sel.deleteFromDocument()
+                sel.getRangeAt(0).insertNode(document.createTextNode(text))
+                sel.collapseToEnd()
+            } else {
+                this.$addressDisplay.textContent += text
+            }
+            this.$addressDisplay.dispatchEvent(new Event("input", { bubbles: true }))
+        })
+        this.listen(this.$addressDisplay, "blur", () => this._syncAddressError())
+        this.listen(this.$addressDisplay, "keydown", (e) => {
+            if (e.key === "Enter") e.preventDefault()
         })
 
         this.listen($amount, "input", () => {
@@ -109,9 +125,10 @@ export class WITHDRAW extends Route {
 
     _syncFormVisibility() {
         const ready = !!(this.$wallets.states.get("currency") && this.$wallets.states.get("chain"))
-        this.$form.hidden = !ready
+        this.$withdrawCard.toggleAttribute("visible", ready)
         if (!ready) {
             this.$form.reset()
+            if (this.$addressDisplay) this.$addressDisplay.textContent = ""
             this.$gas.removeAttribute("visible")
             this.$gas.textContent = ""
             if (this.$addressError) this.$addressError.removeAttribute("visible")
@@ -165,9 +182,60 @@ export class WITHDRAW extends Route {
         }
     }
 
+    _syncAddressValue() {
+        const raw = this.$addressDisplay.textContent
+        this.$addressHidden.value = raw.trim()
+        this._renderAddressHighlight(raw)
+    }
+
+    _renderAddressHighlight(raw) {
+        if (!raw) return
+        const n = raw.length
+
+        // Save caret offset before DOM rewrite
+        const sel = window.getSelection()
+        let caretOffset = n
+        if (sel && sel.rangeCount) {
+            const r = sel.getRangeAt(0)
+            if (this.$addressDisplay.contains(r.startContainer)) {
+                // walk text nodes to accumulate offset
+                let offset = 0
+                const walker = document.createTreeWalker(this.$addressDisplay, NodeFilter.SHOW_TEXT)
+                let node
+                while ((node = walker.nextNode())) {
+                    if (node === r.startContainer) { caretOffset = offset + r.startOffset; break }
+                    offset += node.length
+                }
+            }
+        }
+
+        if (n <= 12) {
+            this.$addressDisplay.innerHTML = `<span class="addr-hi">${raw}</span>`
+        } else {
+            const head = raw.slice(0, 6)
+            const mid = raw.slice(6, n - 6)
+            const tail = raw.slice(n - 6)
+            this.$addressDisplay.innerHTML =
+                `<span class="addr-hi">${head}</span>${mid}<span class="addr-hi">${tail}</span>`
+        }
+
+        // Restore caret at saved offset
+        const range = document.createRange()
+        let remaining = caretOffset
+        const walker = document.createTreeWalker(this.$addressDisplay, NodeFilter.SHOW_TEXT)
+        let node
+        while ((node = walker.nextNode())) {
+            if (remaining <= node.length) { range.setStart(node, remaining); break }
+            remaining -= node.length
+        }
+        range.collapse(true)
+        sel?.removeAllRanges()
+        sel?.addRange(range)
+    }
+
     _syncSubmit() {
         const amount = Number(this.$form?.querySelector("input[name='amount']")?.value)
-        const address = this.$form?.querySelector("input[name='address']")?.value?.trim()
+        const address = this.$addressHidden?.value?.trim()
         const currency = this.$wallets.states.get("currency")
         const chain = this.$wallets.states.get("chain")
         const balance = this.$wallets.states.get("balance")
@@ -177,7 +245,7 @@ export class WITHDRAW extends Route {
     }
 
     _syncAddressError() {
-        const empty = !this.$form.querySelector("input[name='address']")?.value?.trim()
+        const empty = !this.$addressHidden?.value?.trim()
         if (this.$addressError) this.$addressError.toggleAttribute("visible", empty)
     }
 
@@ -191,7 +259,7 @@ export class WITHDRAW extends Route {
             const fee = await SendLogic.gas({
                 wallet: Wallets[chain],
                 name: currency,
-                to: this.$form.querySelector("input[name='address']").value,
+                to: this.$addressHidden.value,
                 amount: this.$form.querySelector("input[name='amount']").value
             })
             if (!fee) {
@@ -230,6 +298,7 @@ export class WITHDRAW extends Route {
         if (result.success) {
             notify({ content: Context.get(["dictionary", "transactionSent"]), autoClose: true })
             this.$form.reset()
+            this.$addressDisplay.textContent = ""
             this.$gas.removeAttribute("visible")
             this.$gas.textContent = ""
         } else notify({ content: Context.get(["dictionary", result.error || "transactionError"]), autoClose: true })

--- a/src/UI/routes/withdraw/styles.css.js
+++ b/src/UI/routes/withdraw/styles.css.js
@@ -1,26 +1,232 @@
 import { css } from "/core/UI.js"
+import { bp } from "/UI/css/breakpoints.js"
 import form from "/css/elements/form.css.js"
 import input from "/css/elements/input.css.js"
-import buttons from "/css/elements/buttons.css.js"
 
 export const styles = css`
     ${form}
     ${input}
-    ${buttons}
+
     :host {
         main {
+            flex: 1;
+            min-height: 0;
             display: flex;
-            align-self: center;
             flex-direction: column;
-            gap: var(--space);
-            max-width: var(--box-width);
+            align-items: center;
+            padding: var(--space) var(--space-sm);
+            gap: var(--space-sm);
         }
-        #gas {
-            font-size: 0.875em;
-            opacity: 0.75;
-            &:empty {
-                display: none;
+
+        ui-card {
+            width: 100%;
+            max-width: 480px;
+        }
+
+        /* Withdraw card grows to fill remaining vertical space */
+        ui-card:last-child {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+        }
+
+        @media (max-width: ${bp.sm}px) {
+            main {
+                padding: var(--space-sm) 0;
             }
+            ui-card {
+                max-width: 100%;
+            }
+        }
+    }
+
+    /* ── Wallet card ── */
+    #wallets {
+        width: 100%;
+        min-height: 0;
+        --wallet-address-wrap-display: none;
+    }
+
+    /* ── Send form ── */
+    #form {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-5);
+        width: 100%;
+        padding: var(--space-4) var(--space-4) 0;
+        box-sizing: border-box;
+
+        &[hidden] {
+            display: none;
+        }
+
+        input {
+            outline: none;
+            font-family: var(--content-font);
+        }
+    }
+
+    /* ── Field layout ── */
+    .field-wrap,
+    .field-label {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+    }
+
+    .field-label-text {
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color);
+        opacity: 0.4;
+        padding-left: var(--space-1);
+    }
+
+    #address-error,
+    #amount-error {
+        margin: 0;
+        font-size: var(--text-xs);
+        color: var(--accent-danger);
+        padding-left: var(--space-1);
+        visibility: hidden;
+
+        &[visible] {
+            visibility: visible;
+        }
+    }
+
+    .amount-label-row {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--space-2);
+    }
+
+    #available-balance {
+        font-size: var(--text-xs);
+        font-family: var(--content-font);
+        color: var(--color);
+        opacity: 0;
+        transition: opacity 0.2s ease;
+        white-space: nowrap;
+
+        &[visible] {
+            opacity: 0.55;
+        }
+    }
+
+    .amount-input-row {
+        position: relative;
+        display: flex;
+        align-items: center;
+
+        input {
+            padding-right: 4rem;
+            width: 100%;
+        }
+    }
+
+    #amount-symbol {
+        position: absolute;
+        right: var(--space);
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--accent-info);
+        text-shadow: var(--glow-info);
+        opacity: 0.75;
+        pointer-events: none;
+        white-space: nowrap;
+
+        &:empty {
+            display: none;
+        }
+    }
+
+    /* ── Disclaimers ── */
+    .disclaimers {
+        list-style: none;
+        margin: 0;
+        padding: 0 var(--space-4);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        flex: 1;
+        justify-content: center;
+
+        li {
+            display: flex;
+            align-items: flex-start;
+            gap: var(--space-2);
+            font-family: var(--content-font);
+            font-size: var(--text-xs);
+            line-height: 1.55;
+            color: var(--color);
+            opacity: 0.45;
+
+            &:first-child {
+                color: var(--accent-warning);
+                opacity: 0.8;
+            }
+        }
+    }
+
+    .disclaimer-icon {
+        width: 0.85em;
+        height: 0.85em;
+        min-width: 0.85em;
+        margin-top: 0.2em;
+        flex-shrink: 0;
+        --svg-color: currentColor;
+    }
+
+    /* ── Bottom actions: gas estimate + submit button ── */
+    .form-actions {
+        margin-top: auto;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-sm);
+        padding: var(--space-sm) 0 var(--space);
+    }
+
+    #gas {
+        font-size: var(--text-xs);
+        opacity: 0.6;
+        font-family: var(--content-font);
+        padding-left: var(--space-1);
+        visibility: hidden;
+
+        &[visible] {
+            visibility: visible;
+        }
+    }
+
+    #submit {
+        --btn-bg: var(--accent-action-surface);
+        --btn-border: var(--border-width) solid var(--accent-action-border);
+        --btn-radius: 0;
+        --btn-padding: var(--space-sm) var(--space);
+        --btn-color: var(--accent-action);
+        --btn-font: var(--header-font);
+        --btn-font-size: var(--text-md);
+        --btn-font-weight: 600;
+        --btn-letter-spacing: 0.12em;
+        --btn-text-transform: uppercase;
+        --btn-bg-hover: color-mix(in hsl, var(--accent-action) 20%, transparent);
+        --btn-color-hover: var(--accent-action);
+        --btn-border-color-hover: var(--accent-action);
+        --btn-glow-hover: var(--glow-action);
+        box-shadow: 0 0 10px var(--accent-action-glow);
+
+        &[disabled] {
+            opacity: 0.35;
+            cursor: not-allowed;
+            pointer-events: none;
+            box-shadow: none;
         }
     }
 `

--- a/src/UI/routes/withdraw/styles.css.js
+++ b/src/UI/routes/withdraw/styles.css.js
@@ -30,6 +30,19 @@ export const styles = css`
             flex-direction: column;
         }
 
+        #withdraw-card {
+            opacity: 0;
+            transform: translateY(8px);
+            pointer-events: none;
+            transition: opacity 0.25s ease, transform 0.25s ease;
+
+            &[visible] {
+                opacity: 1;
+                transform: translateY(0);
+                pointer-events: auto;
+            }
+        }
+
         @media (max-width: ${bp.sm}px) {
             main {
                 padding: var(--space-sm) 0;
@@ -57,14 +70,60 @@ export const styles = css`
         padding: var(--space-4) var(--space-4) 0;
         box-sizing: border-box;
 
-        &[hidden] {
-            display: none;
-        }
-
         input {
             outline: none;
             font-family: var(--content-font);
+            border: 1px solid var(--accent-info-border);
+            box-shadow: 0 0 8px var(--accent-info-glow);
+
+            &:hover, &:focus {
+                border-color: var(--accent-info);
+                box-shadow: 0 0 16px var(--accent-info-border);
+            }
         }
+    }
+
+    /* ── Address display ── */
+    .address-input-wrap {
+        position: relative;
+    }
+
+    .address-display {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        font-family: var(--content-font);
+        font-size: var(--text-sm);
+        color: var(--color);
+        background: transparent;
+        border: 1px solid var(--accent-info-border);
+        box-shadow: 0 0 8px var(--accent-info-glow);
+        border-radius: var(--radius);
+        padding: var(--space-2) var(--space-3);
+        outline: none;
+        white-space: nowrap;
+        overflow: hidden;
+        cursor: text;
+        min-height: 2.6em;
+        line-height: 1.6;
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+        &:hover, &:focus {
+            border-color: var(--accent-info);
+            box-shadow: 0 0 16px var(--accent-info-border);
+        }
+
+        &:empty::before {
+            content: attr(data-placeholder);
+            color: color-mix(in hsl, var(--color) 30%, transparent);
+            pointer-events: none;
+        }
+    }
+
+    .addr-hi {
+        color: var(--neon-c);
+        text-shadow: 0 0 8px color-mix(in hsl, var(--neon-c) 70%, transparent), 0 0 20px color-mix(in hsl, var(--neon-c) 35%, transparent);
+        font-weight: 500;
     }
 
     /* ── Field layout ── */

--- a/src/UI/routes/withdraw/template.js
+++ b/src/UI/routes/withdraw/template.js
@@ -15,13 +15,16 @@ export const template = html`
             <ui-card data-title="wallet">
                 <ui-wallets id="wallets"></ui-wallets>
             </ui-card>
-            <ui-card data-title="withdraw">
+            <ui-card id="withdraw-card" data-title="withdraw">
                 <!-- ── Send form ── -->
-                <form id="form" hidden>
+                <form id="form">
                     <div class="field-wrap">
                         <label class="field-label">
                             <span class="field-label-text"><ui-context data-key="dictionary.address" /></span>
-                            <input type="text" name="address" required />
+                            <div class="address-input-wrap">
+                                <div class="address-display" id="address-display" contenteditable="plaintext-only" spellcheck="false" autocomplete="off" role="textbox" aria-label="address"></div>
+                                <input type="hidden" name="address" id="address-hidden" required />
+                            </div>
                         </label>
                         <p id="address-error">
                             <ui-context data-key="dictionary.addressRequired" />

--- a/src/UI/routes/withdraw/template.js
+++ b/src/UI/routes/withdraw/template.js
@@ -1,26 +1,67 @@
 import { html } from "/core/UI.js"
 import "/UI/layouts/main/index.js"
-import "/UI/components/wallets/index.js"
 import "/UI/components/context/index.js"
+import "/UI/components/svg/index.js"
+import "/UI/components/card/index.js"
+import "/UI/components/modal/index.js"
 import "/UI/components/button/index.js"
+import "/UI/components/wallets/index.js"
 import styles from "./styles.css.js"
 
 export const template = html`
     ${styles}
     <layout-main>
-        <h1><ui-context data-key="dictionary.withdraw" /></h1>
         <main>
-            <ui-wallets />
-            <form id="form">
-                <input type="number" name="amount" min="0" step="any" required disabled />
-                <input type="text" name="address" required disabled />
-                <div id="gas"></div>
-                <div class="buttons">
-                    <ui-button class="full" data-left="send" id="submit">
-                        <ui-context data-key="dictionary.withdraw" />
-                    </ui-button>
-                </div>
-            </form>
+            <ui-card data-title="wallet">
+                <ui-wallets id="wallets"></ui-wallets>
+            </ui-card>
+            <ui-card data-title="withdraw">
+                <!-- ── Send form ── -->
+                <form id="form" hidden>
+                    <div class="field-wrap">
+                        <label class="field-label">
+                            <span class="field-label-text"><ui-context data-key="dictionary.address" /></span>
+                            <input type="text" name="address" required />
+                        </label>
+                        <p id="address-error">
+                            <ui-context data-key="dictionary.addressRequired" />
+                        </p>
+                    </div>
+                    <label class="field-label">
+                        <div class="amount-label-row">
+                            <span class="field-label-text"><ui-context data-key="dictionary.amount" /></span>
+                            <span id="available-balance"></span>
+                        </div>
+                        <div class="amount-input-row">
+                            <input type="number" name="amount" min="0" step="any" required />
+                            <span id="amount-symbol"></span>
+                        </div>
+                        <p id="amount-error">
+                            <ui-context data-key="dictionary.insufficientBalance" />
+                        </p>
+                    </label>
+                    <ul class="disclaimers">
+                        <li>
+                            <ui-svg class="disclaimer-icon" data-src="/images/icons/exclamation-triangle-fill.svg"></ui-svg>
+                            <ui-context data-key="dictionary.wrongChainWarning" />
+                        </li>
+                        <li>
+                            <ui-svg class="disclaimer-icon" data-src="/images/icons/arrow-counterclockwise.svg"></ui-svg>
+                            <ui-context data-key="dictionary.withdrawIrreversible" />
+                        </li>
+                        <li>
+                            <ui-svg class="disclaimer-icon" data-src="/images/icons/shield-check.svg"></ui-svg>
+                            <ui-context data-key="dictionary.withdrawVerifyAddress" />
+                        </li>
+                    </ul>
+                    <div class="form-actions">
+                        <div id="gas"></div>
+                        <ui-button class="full" id="submit" disabled>
+                            <ui-context data-key="dictionary.withdraw" />
+                        </ui-button>
+                    </div>
+                </form>
+            </ui-card>
         </main>
     </layout-main>
 `

--- a/src/core/UI/Component.js
+++ b/src/core/UI/Component.js
@@ -19,11 +19,9 @@ export class Component extends HTMLElement {
     async render() {
         if (!this.template || !this.shadowRoot) return
         render(this.template, this.shadowRoot)
-        
+
         // Re-run onconnect after re-render to reinitialize component state
-        if (typeof this.onconnect === 'function') {
-            this.onconnect()
-        }
+        if (typeof this.onconnect === "function") this.onconnect()
     }
 
     /**
@@ -101,7 +99,7 @@ export class Component extends HTMLElement {
      */
     disconnectedCallback() {
         this.ondisconnect()
-        this.subs.forEach(off => off())
+        this.subs.forEach((off) => off())
         this.subs.length = 0
     }
 }

--- a/src/statics/i18n/addressRequired.yaml
+++ b/src/statics/i18n/addressRequired.yaml
@@ -1,0 +1,18 @@
+ar: العنوان مطلوب
+de: Adresse erforderlich
+en: Address is required
+es: La dirección es obligatoria
+fr: L'adresse est requise
+he: כתובת נדרשת
+hi: पता आवश्यक है
+it: L'indirizzo è obbligatorio
+ja: アドレスは必須です
+ko: 주소가 필요합니다
+no: Adresse er påkrevd
+pt: Endereço é obrigatório
+ru: Адрес обязателен
+th: ต้องระบุที่อยู่
+ur: پتہ ضروری ہے
+vi: Địa chỉ là bắt buộc
+zh: 地址为必填项
+zh-TW: 地址為必填項

--- a/src/statics/i18n/available.yaml
+++ b/src/statics/i18n/available.yaml
@@ -1,0 +1,18 @@
+ar: متاح
+de: Verfügbar
+en: Available
+es: Disponible
+fr: Disponible
+he: זמין
+hi: उपलब्ध
+it: Disponibile
+ja: 利用可能
+ko: 사용 가능
+no: Tilgjengelig
+pt: Disponível
+ru: Доступно
+th: คงเหลือ
+ur: دستیاب
+vi: Khả dụng
+zh: 可用
+zh-TW: 可用

--- a/src/statics/i18n/network.yaml
+++ b/src/statics/i18n/network.yaml
@@ -1,0 +1,18 @@
+ar: الشبكة
+de: Netzwerk
+en: Network
+es: Red
+fr: Réseau
+he: רשת
+hi: नेटवर्क
+it: Rete
+ja: ネットワーク
+ko: 네트워크
+no: Nettverk
+pt: Rede
+ru: Сеть
+th: เครือข่าย
+ur: نیٹ ورک
+vi: Mạng
+zh: 网络
+zh-TW: 網路

--- a/src/statics/i18n/scanToDeposit.yaml
+++ b/src/statics/i18n/scanToDeposit.yaml
@@ -1,0 +1,18 @@
+ar: امسح للإيداع
+de: Zum Einzahlen scannen
+en: Scan to deposit
+es: Escanear para depositar
+fr: Scanner pour déposer
+he: סרוק להפקדה
+hi: जमा करने के लिए स्कैन करें
+it: Scansiona per depositare
+ja: スキャンして入金
+ko: 입금하려면 스캔
+no: Skann for å sette inn
+pt: Escaneie para depositar
+ru: Сканируйте для пополнения
+th: สแกนเพื่อฝากเงิน
+ur: جمع کے لیے اسکین کریں
+vi: Quét để nạp tiền
+zh: 扫码存款
+zh-TW: 掃碼存款

--- a/src/statics/i18n/selectCoin.yaml
+++ b/src/statics/i18n/selectCoin.yaml
@@ -1,0 +1,18 @@
+ar: اختر عملة
+de: Münze wählen
+en: Select Coin
+es: Seleccionar moneda
+fr: Choisir une pièce
+he: בחר מטבע
+hi: सिक्का चुनें
+it: Seleziona moneta
+ja: コインを選択
+ko: 코인 선택
+no: Velg mynt
+pt: Selecionar moeda
+ru: Выберите монету
+th: เลือกเหรียญ
+ur: سکہ منتخب کریں
+vi: Chọn đồng tiền
+zh: 选择币种
+zh-TW: 選擇幣種

--- a/src/statics/i18n/selectNetwork.yaml
+++ b/src/statics/i18n/selectNetwork.yaml
@@ -1,0 +1,18 @@
+ar: اختر شبكة
+de: Netzwerk wählen
+en: Select Network
+es: Seleccionar red
+fr: Choisir un réseau
+he: בחר רשת
+hi: नेटवर्क चुनें
+it: Seleziona rete
+ja: ネットワークを選択
+ko: 네트워크 선택
+no: Velg nettverk
+pt: Selecionar rede
+ru: Выберите сеть
+th: เลือกเครือข่าย
+ur: نیٹ ورک منتخب کریں
+vi: Chọn mạng
+zh: 选择网络
+zh-TW: 選擇網路

--- a/src/statics/i18n/withdrawIrreversible.yaml
+++ b/src/statics/i18n/withdrawIrreversible.yaml
@@ -1,0 +1,18 @@
+ar: المعاملات لا يمكن عكسها بمجرد إرسالها
+de: Transaktionen können nach dem Absenden nicht rückgängig gemacht werden
+en: Transactions cannot be reversed once submitted
+es: Las transacciones no se pueden revertir una vez enviadas
+fr: Les transactions ne peuvent pas être annulées une fois soumises
+he: לא ניתן לבטל עסקאות לאחר שנשלחו
+hi: लेनदेन सबमिट होने के बाद उलटा नहीं किया जा सकता
+it: Le transazioni non possono essere annullate una volta inviate
+ja: 送信済みのトランザクションは取り消せません
+ko: 제출된 트랜잭션은 되돌릴 수 없습니다
+no: Transaksjoner kan ikke reverseres etter at de er sendt
+pt: Transações não podem ser revertidas após o envio
+ru: Транзакции нельзя отменить после отправки
+th: ไม่สามารถยกเลิกธุรกรรมได้หลังจากส่งแล้ว
+ur: ایک بار جمع ہونے کے بعد لین دین کو واپس نہیں کیا جا سکتا
+vi: Giao dịch không thể hoàn tác sau khi đã gửi
+zh: 交易提交后无法撤销
+zh-TW: 交易提交後無法撤銷

--- a/src/statics/i18n/withdrawVerifyAddress.yaml
+++ b/src/statics/i18n/withdrawVerifyAddress.yaml
@@ -1,0 +1,18 @@
+ar: تحقق دائمًا من عنوان المستلم قبل التأكيد
+de: Überprüfen Sie immer die Empfängeradresse vor der Bestätigung
+en: Always verify the recipient address before confirming
+es: Siempre verifica la dirección del destinatario antes de confirmar
+fr: Vérifiez toujours l'adresse du destinataire avant de confirmer
+he: תמיד אמת את כתובת הנמען לפני האישור
+hi: पुष्टि करने से पहले हमेशा प्राप्तकर्ता का पता सत्यापित करें
+it: Verifica sempre l'indirizzo del destinatario prima di confermare
+ja: 確認前に必ず受取人のアドレスを確認してください
+ko: 확인하기 전에 항상 수신자 주소를 확인하세요
+no: Bekreft alltid mottakeradressen før du bekrefter
+pt: Sempre verifique o endereço do destinatário antes de confirmar
+ru: Всегда проверяйте адрес получателя перед подтверждением
+th: ตรวจสอบที่อยู่ผู้รับเสมอก่อนยืนยัน
+ur: تصدیق کرنے سے پہلے ہمیشہ وصول کنندہ کا پتہ تصدیق کریں
+vi: Luôn xác minh địa chỉ người nhận trước khi xác nhận
+zh: 确认前请始终核实收款人地址
+zh-TW: 確認前請務必核實收款人地址

--- a/src/statics/i18n/wrongChainWarning.yaml
+++ b/src/statics/i18n/wrongChainWarning.yaml
@@ -1,0 +1,18 @@
+ar: إرسال على الشبكة الخاطئة سيؤدي إلى فقدان الأموال
+de: Senden auf dem falschen Netzwerk führt zum Verlust der Mittel
+en: Sending on the wrong network will result in permanent loss of funds
+es: Enviar en la red incorrecta resultará en pérdida permanente de fondos
+fr: Envoyer sur le mauvais réseau entraînera une perte permanente de fonds
+he: שליחה ברשת הלא נכונה תגרום לאובדן קבוע של כספים
+hi: गलत नेटवर्क पर भेजने से धन का स्थायी नुकसान होगा
+it: Inviare sulla rete sbagliata comporterà la perdita permanente dei fondi
+ja: 誤ったネットワークへの送金は資金の永久損失を招きます
+ko: 잘못된 네트워크로 전송하면 자금이 영구적으로 손실됩니다
+no: Å sende på feil nettverk vil føre til permanent tap av midler
+pt: Enviar na rede errada resultará em perda permanente de fundos
+ru: Отправка в неверную сеть приведёт к безвозвратной потере средств
+th: การส่งบนเครือข่ายผิดจะทำให้สูญเสียเงินอย่างถาวร
+ur: غلط نیٹ ورک پر بھیجنے سے رقم مستقل طور پر ضائع ہو جائے گی
+vi: Gửi trên mạng sai sẽ dẫn đến mất tiền vĩnh viễn
+zh: 在错误网络上发送将导致资金永久丢失
+zh-TW: 在錯誤網路上發送將導致資金永久損失


### PR DESCRIPTION
## Summary

This PR finalizes the `/deposit` and `/withdraw` routes, adds a pencil edit affordance to the `ui-wallets` name field, and extends `vars.css.js` with a complete set of semantic color tokens for warning and success states — replacing ad-hoc `--accent-danger` usage in contexts where the intent was caution, not error.

---

## Deposit & Withdraw Routes

The `/deposit` and `/withdraw` routes are now fully implemented with coin and network selection modals, address display with QR code for deposit, amount input with balance validation for withdraw, and a disclaimer list covering wrong-chain risk, irreversibility, and address verification. Both routes share the `ui-wallets` component for wallet selection and reuse `ui-modal` and `ui-picker` for the coin/network pickers. Nine i18n keys were added to cover all new strings across all 19 locales.

---

## Wallet Name Edit Affordance

A `#label-edit` pencil button was added to the `#wallet-preview-actions` container in `ui-wallets`. The container is now always visible at rest rather than hidden, with the pencil dim by default and brightening on hover. The button participates in the existing state machine — it hides when a preview is active or the input is focused, and restores when the user returns to resting state. Clicking it programmatically focuses the label input, triggering the existing `showConfirm` flow without any duplicated logic.

---

## Semantic Color Tokens

`vars.css.js` gains `--accent-warning` (→ `--neon-y` amber), `--accent-success` (→ `--neon-g`, distinct alias from `--accent-action`), and `--glow-warning` / `--glow-success` counterparts. Surface, border, and glow companion tokens are now generated consistently for all four accent roles — info, action, success, warning, and danger — replacing previously scattered inline `color-mix()` calls. The chain-warning banners in both deposit and withdraw were updated from `--accent-danger` (magenta) to `--accent-warning` (amber) to correctly reflect their semantic role as a caution, not an error.

---

## Test Plan

- [ ] Visit `/deposit` — coin selector opens modal, selecting a coin filters chain list, selecting a chain shows the wallet address and QR code
- [ ] Visit `/withdraw` — amount input validates against available balance, error message appears when over-limit
- [ ] Wallet name field shows pencil icon at rest; clicking it focuses the input and switches pencil → save button
- [ ] Switching to a preview wallet hides the pencil and shows the switch/delete buttons; committing restores the pencil
- [ ] Chain-warning banner in both deposit and withdraw renders amber, not magenta
- [ ] All new i18n strings render correctly in at least two non-English locales
