### PR TITLE
feat(ui): layout system, grid/container utilities, and game catalog UX

### DIFF
--- a/src/UI/components/camera/styles.css.js
+++ b/src/UI/components/camera/styles.css.js
@@ -21,7 +21,7 @@ const styles = css`
             transform: translateX(-50%);
             width: max-content;
             max-width: calc(100% - (var(--space) * 2));
-            z-index: 2;
+            z-index: var(--z-base);
             text-align: center;
             white-space: normal;
             overflow-wrap: anywhere;

--- a/src/UI/components/devtools/styles.css.js
+++ b/src/UI/components/devtools/styles.css.js
@@ -5,7 +5,7 @@ export const styles = css`
         position: fixed;
         bottom: var(--space-4, 16px);
         right: var(--space-4, 16px);
-        z-index: 9999;
+        z-index: var(--z-devtools);
     }
 
     button {

--- a/src/UI/components/filter-group/index.js
+++ b/src/UI/components/filter-group/index.js
@@ -63,6 +63,7 @@ export class FILTER_GROUP extends Component {
     onconnect() {
         this.$tabs = this.shadowRoot.querySelector("#tabs")
         this.$select = this.shadowRoot.querySelector("#select")
+        this.$choices = this.shadowRoot.querySelector("#choices")
         this._build()
     }
 
@@ -134,11 +135,10 @@ export class FILTER_GROUP extends Component {
         this.$select.value = current ?? ""
         this.$select.classList.toggle("active", !!current)
 
-        // Propagate accent color for rarity selects
+        // Propagate accent color to both tabs and select
         const active = this._options.find((o) => o.value === current)
-        const wrap = this.$select.parentElement
-        if (active?.color) wrap.style.setProperty("--filter-accent", active.color)
-        else wrap.style.removeProperty("--filter-accent")
+        if (active?.color) this.$choices.style.setProperty("--filter-accent", active.color)
+        else this.$choices.style.removeProperty("--filter-accent")
     }
 }
 

--- a/src/UI/components/filter-group/styles.css.js
+++ b/src/UI/components/filter-group/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
 
 export const styles = css`
     :host {
@@ -203,7 +203,7 @@ export const styles = css`
         }
     }
 
-    @media (max-width: ${bp.sm}px) {
+    @media ${mq.sm} {
         .filter-tabs {
             display: none;
         }

--- a/src/UI/components/filter-group/styles.css.js
+++ b/src/UI/components/filter-group/styles.css.js
@@ -54,7 +54,7 @@ export const styles = css`
         letter-spacing: 0.08em;
         text-transform: uppercase;
         padding: var(--space-1) var(--space-3);
-        border: 1px solid var(--border);
+        border: none;
         background: transparent;
         color: var(--color);
         cursor: pointer;
@@ -64,13 +64,11 @@ export const styles = css`
             background var(--speed),
             box-shadow var(--speed);
 
-        &:hover {
-            border-color: var(--filter-accent, var(--accent-info));
-            color: var(--filter-accent, var(--accent-info));
+        &:hover:not([data-color-key]) {
+            color: var(--accent-info);
         }
 
         &.active {
-            border-color: var(--filter-accent, var(--accent-info));
             color: var(--filter-accent, var(--accent-info));
             background: color-mix(in hsl, var(--filter-accent, var(--accent-info)) 6%, transparent);
             box-shadow: 0 0 12px color-mix(in hsl, var(--filter-accent, var(--accent-info)) 25%, transparent);
@@ -79,11 +77,8 @@ export const styles = css`
 
     /* Pill shape variant — applied when host has data-pill attribute */
     :host([data-pill]) .filter-tabs button {
-        border-radius: 999px;
-        padding: var(--space-1) var(--space-2);
-
         /* color swatch dot */
-        &[data-color-key]::before {
+        &[data-color-key]::after {
             content: "";
             display: inline-block;
             flex-shrink: 0;
@@ -92,18 +87,29 @@ export const styles = css`
             border-radius: 50%;
             background: var(--filter-item-color, var(--color));
             opacity: 0.7;
-            margin-right: 0.3em;
+            margin-left: 0.3em;
             vertical-align: middle;
             transition: opacity var(--speed);
         }
 
-        &:hover[data-color-key]::before,
-        &.active[data-color-key]::before {
+        &:hover[data-color-key] {
+            border-color: var(--filter-item-color, var(--accent-info));
+            color: var(--filter-item-color, var(--accent-info));
+        }
+
+        &:hover[data-color-key]::after,
+        &.active[data-color-key]::after {
             opacity: 1;
         }
 
         &.active {
             box-shadow: 0 0 16px color-mix(in hsl, var(--filter-item-color, var(--filter-accent, var(--accent-info))) 40%, transparent);
+        }
+
+        &.active[data-color-key] {
+            border-color: var(--filter-item-color, var(--accent-info));
+            color: var(--filter-item-color, var(--accent-info));
+            background: color-mix(in hsl, var(--filter-item-color, var(--accent-info)) 10%, transparent);
         }
     }
 
@@ -203,7 +209,7 @@ export const styles = css`
         }
     }
 
-    @media ${mq.sm} {
+    @media ${mq.mdDown} {
         .filter-tabs {
             display: none;
         }

--- a/src/UI/components/filter-group/styles.css.js
+++ b/src/UI/components/filter-group/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 
 export const styles = css`
     :host {

--- a/src/UI/components/game-nav/styles.css.js
+++ b/src/UI/components/game-nav/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
 
 export const styles = css`
     :host {
@@ -51,7 +51,7 @@ export const styles = css`
     }
 
     /* ── Mobile: hide fixed toggle (button moves to header) ── */
-    @media (max-width: ${bp.sm}px) {
+    @media ${mq.sm} {
         .game-nav__toggle {
             display: none;
         }

--- a/src/UI/components/game-nav/styles.css.js
+++ b/src/UI/components/game-nav/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 
 export const styles = css`
     :host {

--- a/src/UI/components/header/styles.css.js
+++ b/src/UI/components/header/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
 
 export const styles = css`
     :host {
@@ -33,7 +33,7 @@ export const styles = css`
                 justify-content: space-between;
                 padding: var(--space);
                 position: relative;
-                z-index: 1;
+                z-index: var(--z-base);
 
                 & a,
                 & div {
@@ -51,7 +51,7 @@ export const styles = css`
 
             .games {
                 display: none;
-                @media (max-width: ${bp.sm}px) {
+                @media ${mq.sm} {
                     display: flex;
                 }
             }

--- a/src/UI/components/header/styles.css.js
+++ b/src/UI/components/header/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 
 export const styles = css`
     :host {

--- a/src/UI/components/identicons/styles.css.js
+++ b/src/UI/components/identicons/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
 
 export const styles = css`
     :host {
@@ -37,7 +37,7 @@ export const styles = css`
             display: none;
         }
 
-        @media (min-width: ${bp.sm + 1}px) {
+        @media ${mq.smUp} {
             scrollbar-width: thin;
             scrollbar-color: color-mix(in hsl, var(--color) 25%, transparent) transparent;
             padding-bottom: var(--space-3);

--- a/src/UI/components/identicons/styles.css.js
+++ b/src/UI/components/identicons/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 
 export const styles = css`
     :host {

--- a/src/UI/components/modal/styles.css.js
+++ b/src/UI/components/modal/styles.css.js
@@ -1,4 +1,4 @@
-import container from "/css/elements/container.css.js"
+import container from "/UI/css/layout/container.css.js"
 import scrollbar from "/css/elements/scrollbar.css.js"
 import close from "/css/elements/close.css.js"
 import inAnimation from "/css/animations/in.css.js"

--- a/src/UI/components/navigator/styles.css.js
+++ b/src/UI/components/navigator/styles.css.js
@@ -16,7 +16,7 @@ export const styles = css`
         width: var(--size);
         aspect-ratio: 1 / 1;
         border-radius: 50%;
-        z-index: 1000;
+        z-index: var(--z-dropdown);
 
         nav {
             display: flex;

--- a/src/UI/components/pool/styles.css.js
+++ b/src/UI/components/pool/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
 
 export const styles = css`
     :host {
@@ -141,14 +141,14 @@ export const styles = css`
     }
 
     /* ── Responsive: md (≤1023px) — hide rate column ── */
-    @media (max-width: ${bp.md}px) {
+    @media ${mq.mdDown} {
         .col-rate {
             display: none;
         }
     }
 
     /* ── Responsive: sm (≤767px) — 3-col card: pair | rate | badges ── */
-    @media (max-width: ${bp.sm}px) {
+    @media ${mq.smDown} {
         :host {
             grid-template-columns: 1fr auto auto;
             grid-template-rows: auto auto;

--- a/src/UI/components/pool/styles.css.js
+++ b/src/UI/components/pool/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 
 export const styles = css`
     :host {

--- a/src/UI/components/search/styles.css.js
+++ b/src/UI/components/search/styles.css.js
@@ -13,7 +13,7 @@ export const styles = css`
     .search-input {
         width: 100%;
         background: transparent;
-        border: 1px solid color-mix(in hsl, var(--color) 18%, transparent);
+        border: 1px solid color-mix(in hsl, var(--color) 35%, transparent);
         color: var(--color);
         font-family: var(--header-font);
         font-size: var(--text-sm);

--- a/src/UI/components/swap-form/styles.css.js
+++ b/src/UI/components/swap-form/styles.css.js
@@ -179,7 +179,7 @@ export const styles = css`
         display: flex;
         justify-content: center;
         position: relative;
-        z-index: 1;
+        z-index: var(--z-base);
         margin: calc(var(--space-sm) * -1) 0;
     }
 

--- a/src/UI/css/breakpoints.js
+++ b/src/UI/css/breakpoints.js
@@ -4,23 +4,66 @@
  * CSS custom properties cannot be used inside @media conditions, so breakpoints
  * live here as JS constants and are interpolated into css`` tagged templates.
  *
+ * Three named directions:
+ *
+ *   mq.smUp   — sm and wider   (min-width)
+ *   mq.mdDown — md and below   (max-width, exclusive)
+ *   mq.mdOnly — md tier only   (between md and lg)
+ *
  * Usage:
- *   import { bp } from "/UI/css/breakpoints.js"
+ *   import { mq } from "/UI/css/breakpoints.js"
  *
  *   const styles = css`
- *     .foo { display: grid; }
- *     @media (max-width: ${bp.sm}px) { .foo { display: block; } }
+ *     .foo { display: block; }
+ *     @media ${mq.smUp} { .foo { display: grid; } }
+ *     @media ${mq.mdUp} { .foo { grid-template-columns: repeat(2, 1fr); } }
  *   `
+ *
+ * bp is exported for the rare case where a raw px value is needed
+ * (e.g. hardcoded grid thresholds). Prefer mq in all style files.
  */
 
-/** Raw pixel values — interpolate directly into @media conditions */
+/** Raw pixel values — use mq in styles; bp only when a literal px value is required. */
 export const bp = {
-    xs: 480,    // small phones
-    sm: 767,    // phones / small tablets boundary
-    md: 1023,   // tablets / desktop boundary
-    lg: 1280,   // wide desktop
+    xs:  480,   // small phones
+    sm:  576,   // phones / small tablets
+    md:  768,   // tablets
+    lg:  992,   // desktop
+    xl:  1200,  // wide desktop
+    xxl: 1400,  // ultra-wide
+}
 
-    // Component-specific grid thresholds (catalog grid in game/[game])
-    grid1: 540, // 1-column catalog grid breakpoint
-    grid2: 849, // 2-column catalog grid breakpoint
+/**
+ * Named media query strings — interpolate into @media conditions.
+ *
+ * *Up   — this tier and wider   (mobile-first enhancements, prefer these)
+ * *Down — this tier and below   (use sparingly for overrides)
+ * *Only — exactly this tier     (use rarely for pinpoint tweaks)
+ *
+ * Down uses an exclusive upper edge (bp − 0.02px) to avoid overlap with *Up.
+ */
+export const mq = {
+    // ── Up (min-width) ───────────────────────────────────────────────────────
+    // xs has no Up variant — below sm is the default (no query needed)
+    smUp:  `(min-width: ${bp.sm}px)`,       // ≥576px
+    mdUp:  `(min-width: ${bp.md}px)`,       // ≥768px
+    lgUp:  `(min-width: ${bp.lg}px)`,       // ≥992px
+    xlUp:  `(min-width: ${bp.xl}px)`,       // ≥1200px
+    xxlUp: `(min-width: ${bp.xxl}px)`,      // ≥1400px
+
+    // ── Down (max-width, exclusive) ──────────────────────────────────────────
+    xsDown:  `(max-width: ${bp.xs - 0.02}px)`,   // <480px
+    smDown:  `(max-width: ${bp.sm - 0.02}px)`,   // <576px
+    mdDown:  `(max-width: ${bp.md - 0.02}px)`,   // <768px
+    lgDown:  `(max-width: ${bp.lg - 0.02}px)`,   // <992px
+    xlDown:  `(max-width: ${bp.xl - 0.02}px)`,   // <1200px
+    xxlDown: `(max-width: ${bp.xxl - 0.02}px)`,  // <1400px
+
+    // ── Only (single tier) ───────────────────────────────────────────────────
+    xsOnly:  `(max-width: ${bp.sm - 0.02}px)`,
+    smOnly:  `(min-width: ${bp.sm}px) and (max-width: ${bp.md - 0.02}px)`,
+    mdOnly:  `(min-width: ${bp.md}px) and (max-width: ${bp.lg - 0.02}px)`,
+    lgOnly:  `(min-width: ${bp.lg}px) and (max-width: ${bp.xl - 0.02}px)`,
+    xlOnly:  `(min-width: ${bp.xl}px) and (max-width: ${bp.xxl - 0.02}px)`,
+    // xxlOnly has no upper bound — identical to xxlUp
 }

--- a/src/UI/css/elements/body.css.js
+++ b/src/UI/css/elements/body.css.js
@@ -25,7 +25,7 @@ export const styles = css`
             rgba(0, 0, 0, 0.07) 4px
         );
         pointer-events: none;
-        z-index: 9999;
+        z-index: var(--z-devtools);
     }
 `
 

--- a/src/UI/css/elements/container.css.js
+++ b/src/UI/css/elements/container.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
 
 export const styles = css`
     :host {
@@ -12,11 +12,11 @@ export const styles = css`
             flex-direction: column;
             justify-content: center;
 
-            @media (max-width: ${bp.sm}px) {
+            @media ${mq.smDown} {
                 width: 75%;
             }
 
-            @media (max-width: ${bp.xs}px) {
+            @media ${mq.xsDown} {
                 width: 100%;
             }
         }

--- a/src/UI/css/elements/grid.css.js
+++ b/src/UI/css/elements/grid.css.js
@@ -1,0 +1,66 @@
+import { css } from "/core/UI.js"
+import { bp, mq } from "/UI/css/breakpoints.js"
+
+/**
+ * Shared grid patterns. Import and apply the class to any container.
+ *
+ * .grid          Fixed column count, collapses 3→2→1 at grid2/grid1 breakpoints.
+ *                --grid-cols   (default 3)   number of columns
+ *                --grid-gap    (default --space-3)  uniform gap
+ *                --grid-gap-x  column-gap override
+ *                --grid-gap-y  row-gap override
+ *
+ * .grid--fluid   Auto-fill fluid columns, no breakpoint overrides needed.
+ *                --grid-min    (default 16rem)  minimum column width
+ *                --grid-gap    shared gap token
+ *
+ * .grid--sidebar Fixed sidebar + 1fr main, collapses to 1-col at sm.
+ *                --sidebar-width  (default 15rem)  sidebar column width
+ *                --grid-gap       shared gap token
+ *
+ * .grid--table   Column-contract table rows via --table-cols.
+ *                --table-cols  grid-template-columns value (required)
+ *                Each table defines its own responsive collapse strategy.
+ */
+export const grid = css`
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(var(--grid-cols, 3), 1fr);
+        column-gap: var(--grid-gap-x, var(--grid-gap, var(--space-3)));
+        row-gap: var(--grid-gap-y, var(--grid-gap, var(--space-3)));
+
+        @media (max-width: 849px) {
+            grid-template-columns: repeat(min(var(--grid-cols, 3), 2), 1fr);
+        }
+
+        @media (max-width: 540px) {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    .grid--fluid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(var(--grid-min, 16rem), 1fr));
+        column-gap: var(--grid-gap-x, var(--grid-gap, var(--space-3)));
+        row-gap: var(--grid-gap-y, var(--grid-gap, var(--space-3)));
+    }
+
+    .grid--sidebar {
+        display: grid;
+        grid-template-columns: var(--sidebar-width, 15rem) 1fr;
+        column-gap: var(--grid-gap-x, var(--grid-gap, var(--space-3)));
+        row-gap: var(--grid-gap-y, var(--grid-gap, var(--space-3)));
+
+        @media ${mq.sm} {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    .grid--table {
+        display: grid;
+        grid-template-columns: var(--table-cols);
+        align-items: center;
+    }
+`
+
+export default grid

--- a/src/UI/css/layout/breakpoints.js
+++ b/src/UI/css/layout/breakpoints.js
@@ -11,7 +11,7 @@
  *   mq.mdOnly — md tier only   (between md and lg)
  *
  * Usage:
- *   import { mq } from "/UI/css/breakpoints.js"
+ *   import { mq } from "/UI/css/layout/breakpoints.js"
  *
  *   const styles = css`
  *     .foo { display: block; }

--- a/src/UI/css/layout/container.css.js
+++ b/src/UI/css/layout/container.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 
 export const styles = css`
     :host {

--- a/src/UI/css/layout/grid.css.js
+++ b/src/UI/css/layout/grid.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp, mq } from "/UI/css/breakpoints.js"
+import { bp, mq } from "/UI/css/layout/breakpoints.js"
 
 /**
  * Shared grid patterns. Import and apply the class to any container.
@@ -51,7 +51,7 @@ export const grid = css`
         column-gap: var(--grid-gap-x, var(--grid-gap, var(--space-3)));
         row-gap: var(--grid-gap-y, var(--grid-gap, var(--space-3)));
 
-        @media ${mq.sm} {
+        @media ${mq.smDown} {
             grid-template-columns: 1fr;
         }
     }

--- a/src/UI/css/vars.css.js
+++ b/src/UI/css/vars.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 
 export const styles = css`
     :root {

--- a/src/UI/css/vars.css.js
+++ b/src/UI/css/vars.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
 
 export const styles = css`
     :root {
@@ -36,11 +36,11 @@ export const styles = css`
         /* Typography — fluid via clamp(min, viewport, max).
            Max values match the previous fixed sizes (0.125rem × multiplier).
            Min values keep text legible on small phones. */
-        --text-xs: clamp(0.65rem,  1.5vw, 0.75rem);
-        --text-sm: clamp(0.75rem,  1.8vw, 0.875rem);
-        --text-md: clamp(0.875rem, 2vw,   1rem);
-        --text-lg: clamp(1rem,     2.5vw, 1.25rem);
-        --text-xl: clamp(1.25rem,  3vw,   1.5rem);
+        --text-xs: clamp(0.65rem, 1.5vw, 0.75rem);
+        --text-sm: clamp(0.75rem, 1.8vw, 0.875rem);
+        --text-md: clamp(0.875rem, 2vw, 1rem);
+        --text-lg: clamp(1rem, 2.5vw, 1.25rem);
+        --text-xl: clamp(1.25rem, 3vw, 1.5rem);
         --text: var(--text-md);
 
         /* Animation */
@@ -114,7 +114,7 @@ export const styles = css`
         --icon-md: var(--unit-6);
         --icon-lg: var(--unit-7);
         --icon-xlg: var(--unit-10);
-        --icon-2xl: var(--unit-9);   /* 6rem = 96px */
+        --icon-2xl: var(--unit-9); /* 6rem = 96px */
         --icon: var(--icon-md);
 
         /* Icon Masks — square viewBox, default direction left; rotate() to repoint */
@@ -124,6 +124,13 @@ export const styles = css`
         --max-width: 80rem;
         --content-width: min(100% - var(--space-4), var(--max-width));
         --box-width: calc((min(100vw, 100vh) - var(--space-4)) * 0.75);
+
+        --container-sm: 33.75rem; /* 540px  — phone landscape cap */
+        --container-md: 45rem; /* 720px  — tablet cap          */
+        --container-lg: 60rem; /* 960px  — desktop cap         */
+        --container-xl: 71.25rem; /* 1140px — wide desktop cap    */
+        --container-xxl: 82.5rem; /* 1320px — ultra-wide cap      */
+        --container-form: 30rem; /* 480px  — narrow form/card    */
 
         /* Font */
         --header-font: "Orbitron", system-ui, sans-serif;
@@ -140,7 +147,6 @@ export const styles = css`
         --glow-g: 0 0 8px #00ff9d88, 0 0 24px #00ff9d33;
         --glow-c: 0 0 8px #00e5ff88, 0 0 24px #00e5ff33;
         --glow-m: 0 0 8px #ff2d7888, 0 0 24px #ff2d7833;
-        --glow-y: 0 0 8px #f5e64288, 0 0 24px #f5e64233;
         --glow-y: 0 0 8px #f5e64288, 0 0 24px #f5e64233;
 
         /* Layout hooks */
@@ -180,11 +186,11 @@ export const styles = css`
         --field-inset-border: color-mix(in hsl, var(--navy-700) 60%, transparent);
 
         /* Semantic interactive accents */
-        --accent-info: var(--neon-c);       /* filters, search, links, info states */
-        --accent-action: var(--neon-g);     /* confirm, submit, price, positive */
-        --accent-success: var(--neon-g);    /* success states, completed actions */
-        --accent-warning: var(--neon-y);    /* caution, irreversible actions, pre-error */
-        --accent-danger: var(--neon-m);     /* error, destructive, blocked */
+        --accent-info: var(--neon-c); /* filters, search, links, info states */
+        --accent-action: var(--neon-g); /* confirm, submit, price, positive */
+        --accent-success: var(--neon-g); /* success states, completed actions */
+        --accent-warning: var(--neon-y); /* caution, irreversible actions, pre-error */
+        --accent-danger: var(--neon-m); /* error, destructive, blocked */
         --glow-info: var(--glow-c);
         --glow-action: var(--glow-g);
         --glow-success: var(--glow-g);
@@ -192,21 +198,21 @@ export const styles = css`
         --glow-danger: var(--glow-m);
 
         /* Interactive surface tokens — resting border, glow shadow, hover/selected fill */
-        --accent-info-border:       color-mix(in hsl, var(--accent-info)    35%, transparent);
-        --accent-info-glow:         color-mix(in hsl, var(--accent-info)    12%, transparent);
-        --accent-info-surface:      color-mix(in hsl, var(--accent-info)     8%, transparent);
-        --accent-action-border:     color-mix(in hsl, var(--accent-action)  50%, transparent);
-        --accent-action-glow:       color-mix(in hsl, var(--accent-action)  20%, transparent);
-        --accent-action-surface:    color-mix(in hsl, var(--accent-action)  12%, transparent);
-        --accent-success-border:    color-mix(in hsl, var(--accent-success) 50%, transparent);
-        --accent-success-glow:      color-mix(in hsl, var(--accent-success) 20%, transparent);
-        --accent-success-surface:   color-mix(in hsl, var(--accent-success) 12%, transparent);
-        --accent-warning-border:    color-mix(in hsl, var(--accent-warning) 40%, transparent);
-        --accent-warning-glow:      color-mix(in hsl, var(--accent-warning) 15%, transparent);
-        --accent-warning-surface:   color-mix(in hsl, var(--accent-warning) 10%, transparent);
-        --accent-danger-border:     color-mix(in hsl, var(--accent-danger)  35%, transparent);
-        --accent-danger-glow:       color-mix(in hsl, var(--accent-danger)  12%, transparent);
-        --accent-danger-surface:    color-mix(in hsl, var(--accent-danger)   8%, transparent);
+        --accent-info-border: color-mix(in hsl, var(--accent-info) 35%, transparent);
+        --accent-info-glow: color-mix(in hsl, var(--accent-info) 12%, transparent);
+        --accent-info-surface: color-mix(in hsl, var(--accent-info) 8%, transparent);
+        --accent-action-border: color-mix(in hsl, var(--accent-action) 50%, transparent);
+        --accent-action-glow: color-mix(in hsl, var(--accent-action) 20%, transparent);
+        --accent-action-surface: color-mix(in hsl, var(--accent-action) 12%, transparent);
+        --accent-success-border: color-mix(in hsl, var(--accent-success) 50%, transparent);
+        --accent-success-glow: color-mix(in hsl, var(--accent-success) 20%, transparent);
+        --accent-success-surface: color-mix(in hsl, var(--accent-success) 12%, transparent);
+        --accent-warning-border: color-mix(in hsl, var(--accent-warning) 40%, transparent);
+        --accent-warning-glow: color-mix(in hsl, var(--accent-warning) 15%, transparent);
+        --accent-warning-surface: color-mix(in hsl, var(--accent-warning) 10%, transparent);
+        --accent-danger-border: color-mix(in hsl, var(--accent-danger) 35%, transparent);
+        --accent-danger-glow: color-mix(in hsl, var(--accent-danger) 12%, transparent);
+        --accent-danger-surface: color-mix(in hsl, var(--accent-danger) 8%, transparent);
 
         /* Item cards */
         --item-border-left: 3px solid var(--neon-c);
@@ -238,14 +244,18 @@ export const styles = css`
 
         /* Z-index Layers */
         --z-base: 0;
-        --z-sticky: 50;
-        --z-dropdown: 100;
+        --z-sticky: 50; /* sticky catalog bands             */
+        --z-dropdown: 100; /* dropdowns, navigator             */
         --z-panel-toggle: 200;
         --z-panel-backdrop: 210;
         --z-panel: 220;
+        --z-modal-backdrop: 290; /* sits just below modal            */
         --z-modal: 300;
         --z-overlay: 400;
         --z-toast: 500;
+        --z-picker-backdrop: 590; /* sits just below picker           */
+        --z-picker: 600; /* avatar picker, floating pickers  */
+        --z-devtools: 999; /* internal dev tooling only        */
 
         /* Blur Scale */
         --blur-xs: 2px;
@@ -269,21 +279,25 @@ export const styles = css`
 
         /* Hero layout */
         --hero-pad-top: clamp(5rem, 13vw, 9rem);
-        --avatar-size:  clamp(5rem, 12vw, 8rem);
+        --avatar-size: clamp(5rem, 12vw, 8rem);
     }
 
-    @media (max-width: ${bp.md}px) {
-        :root { --hero-pad-top: clamp(4rem, 11vw, 7rem); }
+    @media ${mq.mdDown} {
+        :root {
+            --hero-pad-top: clamp(4rem, 11vw, 7rem);
+        }
     }
 
-    @media (max-width: ${bp.sm}px) {
-        :root { --hero-pad-top: clamp(3.5rem, 10vw, 6rem); }
+    @media ${mq.smDown} {
+        :root {
+            --hero-pad-top: clamp(3.5rem, 10vw, 6rem);
+        }
     }
 
-    @media (max-width: ${bp.xs}px) {
+    @media ${mq.xsDown} {
         :root {
             --hero-pad-top: clamp(3rem, 9vw, 4.5rem);
-            --avatar-size:  clamp(4rem, 10vw, 5.5rem);
+            --avatar-size: clamp(4rem, 10vw, 5.5rem);
         }
     }
 

--- a/src/UI/css/vars.css.js
+++ b/src/UI/css/vars.css.js
@@ -117,9 +117,6 @@ export const styles = css`
         --icon-2xl: var(--unit-9); /* 6rem = 96px */
         --icon: var(--icon-md);
 
-        /* Icon Masks — square viewBox, default direction left; rotate() to repoint */
-        --icon-chevron-double: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M7 11 L4 8 L7 5 M12 11 L9 8 L12 5' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-
         /* Layout */
         --max-width: 80rem;
         --content-width: min(100% - var(--space-4), var(--max-width));

--- a/src/UI/routes/game/[game]/index.js
+++ b/src/UI/routes/game/[game]/index.js
@@ -24,8 +24,8 @@ async function loadItemsBatched(ids, gameId, locale) {
 
 const SORT_OPTIONS = [
     { key: "name", label: "Name", asc: "name", desc: "name-desc", indAsc: "↑", indDesc: "↓" },
-    { key: "rarity", label: "Rarity", asc: "rarity-asc", desc: "rarity-desc", indAsc: "↑", indDesc: "↓" },
-    { key: "price", label: "Price", asc: "value-asc", desc: "value-desc", indAsc: "↑", indDesc: "↓" }
+    { key: "price", label: "Price", asc: "value-asc", desc: "value-desc", indAsc: "↑", indDesc: "↓" },
+    { key: "rarity", label: "Rarity", asc: "rarity-asc", desc: "rarity-desc", indAsc: "↑", indDesc: "↓" }
 ]
 
 export class GAME extends HTMLElement {
@@ -60,147 +60,166 @@ export class GAME extends HTMLElement {
     async connectedCallback() {
         this.subs.push(Context.on("locale", this.render))
         await this.render()
+        this._setupStickyPill()
+    }
 
-        // ── Sticky sentinel — detect when .catalog-sticky has stuck ──
+    _setupStickyPill() {
         const sticky = this.shadowRoot.querySelector(".catalog-sticky")
         const sentinel = this.shadowRoot.querySelector(".sticky-sentinel")
         const pill = this.shadowRoot.querySelector("#catalog-pill")
-        if (sticky && sentinel) {
-            const stickyTopPx = parseInt(getComputedStyle(sticky).top) || 0
+        if (!sticky || !sentinel) return
 
-            // Sets the inline pixel width that acts as the "from" value for transitions.
-            // Called after any change that may resize the pill (stuck, filter change).
-            const syncPillWidth = () => {
+        const stickyTopPx = parseInt(getComputedStyle(sticky).top) || 0
+
+        // Sets the inline pixel width that acts as the "from" value for transitions.
+        // Called after any change that may resize the pill (stuck, filter change).
+        const syncPillWidth = () => {
+            if (!pill) return
+            if (window.matchMedia("(min-width: 768px)").matches) return
+            this._pillWidth = pill.getBoundingClientRect().width
+            sticky.style.width = this._pillWidth + "px"
+        }
+
+        // Collapses to pill with an animated transition (used for explicit user actions).
+        // Two-frame technique to get a CSS width transition from full-width → pill-width:
+        //   Frame 1: pin the current px width as inline style (gives transition a "from"),
+        //            remove is-expanded so CSS rules for the collapsed state apply.
+        //   Between frames: browser resolves layout with fit-content on the pill.
+        //   Frame 2: measure the natural pill width and write it as inline style ("to").
+        //            The transition on .catalog-sticky then animates between the two.
+        const animateCollapse = () => {
+            // Frame 1 — lock in current rendered width and drop is-expanded.
+            sticky.style.width = sticky.getBoundingClientRect().width + "px"
+            sticky.classList.remove("is-expanded")
+            // Frame 2 — measure the pill's natural fit-content width and set as target.
+            requestAnimationFrame(() => {
                 if (!pill) return
-                if (window.matchMedia("(min-width: 1024px)").matches) return
                 this._pillWidth = pill.getBoundingClientRect().width
                 sticky.style.width = this._pillWidth + "px"
-            }
-
-            // Collapses to pill with an animated transition (used for explicit user actions).
-            const animateCollapse = () => {
-                // Set the numeric target width + remove .is-expanded in one style flush.
-                // Browser sees: from 100% (CSS .is-stuck.is-expanded) → to _pillWidth px (inline).
-                if (this._pillWidth) sticky.style.width = this._pillWidth + "px"
-                sticky.classList.remove("is-expanded")
-            }
-
-            this._stickyObserver = new IntersectionObserver(
-                ([entry]) => {
-                    if (!entry.isIntersecting) {
-                        // Scroll-triggered stick: instant snap.
-                        // Add class first, then measure synchronously — getBoundingClientRect()
-                        // forces a style recalculation so .is-stuck CSS (including
-                        // width: fit-content on .catalog-pill) is applied before we measure.
-                        sticky.classList.add("is-stuck")
-                        syncPillWidth()
-                    } else {
-                        // Scroll-triggered unstick: instant snap back to full bar.
-                        sticky.style.width = ""
-                        sticky.classList.remove("is-stuck", "is-expanded")
-                    }
-                },
-                { rootMargin: `-${stickyTopPx}px 0px 0px 0px`, threshold: 0 }
-            )
-            this._stickyObserver.observe(sentinel)
-            this.subs.push(() => this._stickyObserver.disconnect())
-
-            // Pill click → expand (animated).
-            // Clear inline px width + add .is-expanded in one flush.
-            // Browser sees: from _pillWidth px (inline) → to 100% (CSS .is-stuck.is-expanded).
-            const expandSticky = () => {
-                sticky.style.width = ""
-                sticky.classList.add("is-expanded")
-            }
-
-            if (pill) {
-                pill.addEventListener("click", expandSticky)
-                this.subs.push(() => pill.removeEventListener("click", expandSticky))
-            }
-
-            // Individual pill segment actions — each stops propagation so the
-            // general pill-expand doesn't also fire, then handles its own action.
-
-            const pillSortEl = this.shadowRoot.querySelector("#pill-sort")
-            if (pillSortEl) {
-                const onPillSort = (e) => {
-                    e.stopPropagation()
-                    const sortCycle = SORT_OPTIONS.flatMap((o) => [o.asc, o.desc])
-                    const current = this.states.get("sort")
-                    const idx = sortCycle.indexOf(current)
-                    const next = sortCycle[(idx + 1) % sortCycle.length]
-                    this.states.set({ sort: next })
-                    this._displayPage = 1
-                    this.applyFilters()
-                }
-                pillSortEl.addEventListener("click", onPillSort)
-                this.subs.push(() => pillSortEl.removeEventListener("click", onPillSort))
-            }
-
-            const pillTypeEl = this.shadowRoot.querySelector("#pill-type")
-            if (pillTypeEl) {
-                const onPillType = (e) => {
-                    e.stopPropagation()
-                    expandSticky()
-                    requestAnimationFrame(() => {
-                        const selectWrap = this.shadowRoot.querySelector("#type-select")?.closest(".filter-select-wrap")
-                        if (selectWrap && getComputedStyle(selectWrap).display !== "none") this.shadowRoot.querySelector("#type-select").focus()
-                        else this.shadowRoot.querySelector("#type-tabs button")?.focus()
-                    })
-                }
-                pillTypeEl.addEventListener("click", onPillType)
-                this.subs.push(() => pillTypeEl.removeEventListener("click", onPillType))
-            }
-
-            const pillRarityDotEl = this.shadowRoot.querySelector("#pill-rarity-dot")
-            if (pillRarityDotEl) {
-                const onPillRarityDot = (e) => {
-                    e.stopPropagation()
-                    expandSticky()
-                    requestAnimationFrame(() => {
-                        const selectWrap = this.shadowRoot.querySelector("#rarity-select")?.closest(".filter-select-wrap")
-                        if (selectWrap && getComputedStyle(selectWrap).display !== "none") this.shadowRoot.querySelector("#rarity-select").focus()
-                        else this.shadowRoot.querySelector(".rarity-pills button")?.focus()
-                    })
-                }
-                pillRarityDotEl.addEventListener("click", onPillRarityDot)
-                this.subs.push(() => pillRarityDotEl.removeEventListener("click", onPillRarityDot))
-            }
-
-            const pillSearchEl = this.shadowRoot.querySelector("#pill-search")
-            if (pillSearchEl) {
-                const onPillSearch = (e) => {
-                    e.stopPropagation()
-                    expandSticky()
-                    requestAnimationFrame(() => this.shadowRoot.querySelector("#search")?.focus())
-                }
-                pillSearchEl.addEventListener("click", onPillSearch)
-                this.subs.push(() => pillSearchEl.removeEventListener("click", onPillSearch))
-            }
-            // ui-search exposes focus() which delegates to its inner input
-
-            // Collapse button → collapse (animated).
-            const collapseBtn = this.shadowRoot.querySelector("#catalog-collapse")
-            if (collapseBtn) {
-                const onCollapse = (e) => {
-                    e.stopPropagation()
-                    animateCollapse()
-                }
-                collapseBtn.addEventListener("click", onCollapse)
-                this.subs.push(() => collapseBtn.removeEventListener("click", onCollapse))
-            }
-
-            // Pointer outside → collapse (animated).
-            this._onPointerDown = (e) => {
-                if (!sticky.classList.contains("is-expanded")) return
-                if (!e.composedPath().includes(sticky)) animateCollapse()
-            }
-            document.addEventListener("pointerdown", this._onPointerDown)
-            this.subs.push(() => document.removeEventListener("pointerdown", this._onPointerDown))
-
-            // Store syncPillWidth so applyFilters can update the width when pill content changes.
-            this._syncPillWidth = syncPillWidth
+            })
         }
+
+        // Expands to full bar with an animated transition.
+        // Browser sees: from _pillWidth px (inline) → to 100% (CSS .is-stuck.is-expanded).
+        const expandSticky = () => {
+            sticky.style.width = ""
+            sticky.classList.add("is-expanded")
+        }
+
+        this._setupStickyObserver(sticky, sentinel, stickyTopPx, syncPillWidth)
+        this._setupPillExpand(pill, expandSticky)
+        this._setupPillSegments(expandSticky)
+        this._setupCollapseControls(sticky, animateCollapse)
+
+        // Store syncPillWidth so applyFilters can update the width when pill content changes.
+        this._syncPillWidth = syncPillWidth
+    }
+
+    _setupStickyObserver(sticky, sentinel, stickyTopPx, syncPillWidth) {
+        this._stickyObserver = new IntersectionObserver(
+            ([entry]) => {
+                if (!entry.isIntersecting) {
+                    // Scroll-triggered stick: instant snap.
+                    // Add class first, then measure synchronously — getBoundingClientRect()
+                    // forces a style recalculation so .is-stuck CSS (including
+                    // width: fit-content on .catalog-pill) is applied before we measure.
+                    sticky.classList.add("is-stuck")
+                    syncPillWidth()
+                } else {
+                    // Scroll-triggered unstick: instant snap back to full bar.
+                    sticky.style.width = ""
+                    sticky.classList.remove("is-stuck", "is-expanded")
+                }
+            },
+            { rootMargin: `-${stickyTopPx}px 0px 0px 0px`, threshold: 0 }
+        )
+        this._stickyObserver.observe(sentinel)
+        this.subs.push(() => this._stickyObserver.disconnect())
+    }
+
+    _setupPillExpand(pill, expandSticky) {
+        if (!pill) return
+        pill.addEventListener("click", expandSticky)
+        this.subs.push(() => pill.removeEventListener("click", expandSticky))
+    }
+
+    // Individual pill segment actions — each stops propagation so the
+    // general pill-expand doesn't also fire, then handles its own action.
+    _setupPillSegments(expandSticky) {
+        const pillSortEl = this.shadowRoot.querySelector("#pill-sort")
+        if (pillSortEl) {
+            const onPillSort = (e) => {
+                e.stopPropagation()
+                const sortCycle = SORT_OPTIONS.flatMap((o) => [o.asc, o.desc])
+                const current = this.states.get("sort")
+                const idx = sortCycle.indexOf(current)
+                const next = sortCycle[(idx + 1) % sortCycle.length]
+                this.states.set({ sort: next })
+                this._displayPage = 1
+                this.applyFilters()
+            }
+            pillSortEl.addEventListener("click", onPillSort)
+            this.subs.push(() => pillSortEl.removeEventListener("click", onPillSort))
+        }
+
+        const pillTypeEl = this.shadowRoot.querySelector("#pill-type")
+        if (pillTypeEl) {
+            const onPillType = (e) => {
+                e.stopPropagation()
+                expandSticky()
+                requestAnimationFrame(() => this.shadowRoot.querySelector("#type-filter")?.shadowRoot?.querySelector("#select")?.focus())
+            }
+            pillTypeEl.addEventListener("click", onPillType)
+            this.subs.push(() => pillTypeEl.removeEventListener("click", onPillType))
+        }
+
+        const pillRarityDotEl = this.shadowRoot.querySelector("#pill-rarity-dot")
+        if (pillRarityDotEl) {
+            const onPillRarityDot = (e) => {
+                e.stopPropagation()
+                expandSticky()
+                requestAnimationFrame(() => this.shadowRoot.querySelector("#rarity-filter")?.shadowRoot?.querySelector("#select")?.focus())
+            }
+            pillRarityDotEl.addEventListener("click", onPillRarityDot)
+            pillRarityDotEl.addEventListener("keydown", (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    onPillRarityDot(e)
+                }
+            })
+            this.subs.push(() => pillRarityDotEl.removeEventListener("click", onPillRarityDot))
+        }
+
+        const pillSearchEl = this.shadowRoot.querySelector("#pill-search")
+        if (pillSearchEl) {
+            const onPillSearch = (e) => {
+                e.stopPropagation()
+                expandSticky()
+                requestAnimationFrame(() => this.shadowRoot.querySelector("#search")?.focus())
+            }
+            pillSearchEl.addEventListener("click", onPillSearch)
+            this.subs.push(() => pillSearchEl.removeEventListener("click", onPillSearch))
+        }
+    }
+
+    _setupCollapseControls(sticky, animateCollapse) {
+        const collapseBtn = this.shadowRoot.querySelector("#catalog-collapse")
+        if (collapseBtn) {
+            const onCollapse = (e) => {
+                e.stopPropagation()
+                animateCollapse()
+            }
+            collapseBtn.addEventListener("click", onCollapse)
+            this.subs.push(() => collapseBtn.removeEventListener("click", onCollapse))
+        }
+
+        // Pointer outside → collapse (animated).
+        this._onPointerDown = (e) => {
+            if (!sticky.classList.contains("is-expanded")) return
+            if (!e.composedPath().includes(sticky)) animateCollapse()
+        }
+        document.addEventListener("pointerdown", this._onPointerDown)
+        this.subs.push(() => document.removeEventListener("pointerdown", this._onPointerDown))
     }
 
     disconnectedCallback() {
@@ -268,14 +287,10 @@ export class GAME extends HTMLElement {
         const pillSort = this.shadowRoot.querySelector("#pill-sort")
         const pillSearch = this.shadowRoot.querySelector("#pill-search")
 
-        if (pillType)
-            if (activeType) {
-                pillType.textContent = activeType
-                pillType.classList.add("active")
-            } else {
-                pillType.textContent = "All"
-                pillType.classList.remove("active")
-            }
+        if (pillType) {
+            pillType.textContent = activeType || "All"
+            pillType.classList.add("active")
+        }
 
         if (pillRarityDot)
             if (activeRarity) {
@@ -311,6 +326,17 @@ export class GAME extends HTMLElement {
         })
         grid.replaceChildren(...elements)
 
+        // Empty state — only show when background loading is done and nothing matched
+        const emptyEl = this.shadowRoot.querySelector("#items-empty")
+        if (emptyEl) {
+            const isEmpty = !this._readyPromise && filtered.length === 0
+            emptyEl.hidden = !isEmpty
+            if (isEmpty) {
+                const dict = Context.get("dictionary") || {}
+                emptyEl.textContent = dict.noItemsFound || "No items found"
+            }
+        }
+
         // Load More — client-side only, advances the display window over in-memory data
         const loadMoreBtn = this.shadowRoot.querySelector("#load-more")
         if (loadMoreBtn) {
@@ -334,6 +360,7 @@ export class GAME extends HTMLElement {
             btn.classList.toggle("active", isAsc || isDesc)
             const dirEl = btn.querySelector(".sort-dir")
             if (dirEl) dirEl.textContent = isAsc ? btn.dataset.indAsc : isDesc ? btn.dataset.indDesc : ""
+            if (btn.dataset.sortKey === "rarity") btn.disabled = !!activeRarity
         })
     }
 
@@ -440,7 +467,7 @@ export class GAME extends HTMLElement {
 
         // Build type filter
         const typeFilter = this.shadowRoot.querySelector("#type-filter")
-        typeFilter.allLabel = "All Types"
+        typeFilter.allLabel = dict.all || "All"
         typeFilter.options = types.map((t) => ({ label: t, value: t }))
         typeFilter.value = this.states.get("activeType")
         typeFilter.addEventListener("filter", (e) => {
@@ -450,14 +477,21 @@ export class GAME extends HTMLElement {
 
         // Build rarity filter
         const rarityFilter = this.shadowRoot.querySelector("#rarity-filter")
-        rarityFilter.allLabel = "All Rarities"
+        rarityFilter.allLabel = dict.all || "All"
+        rarityFilter.maxVisible = rarities.length
         rarityFilter.options = rarities.map((r) => {
             const key = r.toLowerCase().replace(/\s+/g, "-")
             return { label: r, value: r, color: `var(--rarity-${key}, var(--color-accent))` }
         })
         rarityFilter.value = this.states.get("activeRarity")
         rarityFilter.addEventListener("filter", (e) => {
-            this.states.set({ activeRarity: e.detail.value })
+            const updates = { activeRarity: e.detail.value }
+            if (e.detail.value) {
+                const sort = this.states.get("sort")
+                const rarityOpt = SORT_OPTIONS.find((o) => o.key === "rarity")
+                if (sort === rarityOpt.asc || sort === rarityOpt.desc) updates.sort = "name"
+            }
+            this.states.set(updates)
             this._handleFilterChange()
         })
 
@@ -502,20 +536,30 @@ export class GAME extends HTMLElement {
             })
             return btn
         })
-        sortBar.replaceChildren(...sortButtons)
+        const sortLabel = document.createElement("span")
+        sortLabel.className = "sort-bar__label"
+        sortLabel.textContent = "SORT BY "
+        sortBar.replaceChildren(sortLabel, ...sortButtons)
 
         // Lock every sort button to the same width so switching active option
         // never shifts the search input. Measure at the widest possible indicator
         // text ("A→Z"), then restore empty dir slots and pin min-width.
-        const allDirs = [...sortBar.querySelectorAll(".sort-dir")]
+        // Measure the widest button label, then add the arrow glyph + gap on top.
+        // We can't rely on toggling .active + offsetWidth because the nested CSS selector
+        // (.sort-bar button.active .sort-dir) may not reflow in time. Instead:
+        //   1. Force all dirs to display:inline-block via inline style so they're measurable.
+        //   2. Set arrow text and read the widest button.
+        //   3. Restore dirs and pin min-width on all buttons.
+        const buttons = [...sortBar.querySelectorAll("button")]
+        const allDirs = buttons.map((b) => b.querySelector(".sort-dir"))
         allDirs.forEach((d) => {
-            d.textContent = "↑"
+            if (d) { d.style.display = "inline-block"; d.textContent = "↑" }
         })
-        const maxBtnW = Math.max(...[...sortBar.children].map((b) => b.offsetWidth))
+        const maxBtnW = Math.max(...buttons.map((b) => b.offsetWidth))
         allDirs.forEach((d) => {
-            d.textContent = ""
+            if (d) { d.style.display = ""; d.textContent = "" }
         })
-        sortBar.querySelectorAll("button").forEach((b) => {
+        buttons.forEach((b) => {
             b.style.minWidth = `${maxBtnW}px`
         })
 
@@ -528,7 +572,6 @@ export class GAME extends HTMLElement {
 
         this.applyFilters()
     }
-
 }
 
 customElements.define("route-game", GAME)

--- a/src/UI/routes/game/[game]/styles.css.js
+++ b/src/UI/routes/game/[game]/styles.css.js
@@ -1,6 +1,6 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
-import grid from "/UI/css/elements/grid.css.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
+import grid from "/UI/css/layout/grid.css.js"
 
 const gameColor = `var(--game-text-color, var(--game-primary, var(--neon-c)))`
 const gamePrimary = `var(--game-primary, var(--neon-c))`

--- a/src/UI/routes/game/[game]/styles.css.js
+++ b/src/UI/routes/game/[game]/styles.css.js
@@ -1,7 +1,13 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
+import grid from "/UI/css/elements/grid.css.js"
+
+const gameColor = `var(--game-text-color, var(--game-primary, var(--neon-c)))`
+const gamePrimary = `var(--game-primary, var(--neon-c))`
+const labelFont = `font-family: var(--header-font); font-size: var(--text-xs); letter-spacing: 0.06em; text-transform: uppercase;`
 
 export const styles = css`
+    ${grid}
     :host {
         display: block;
         overflow-x: clip;
@@ -42,10 +48,8 @@ export const styles = css`
             }
 
             .game-hero__pill {
-                font-size: var(--text-xs);
-                font-family: var(--header-font);
+                ${labelFont}
                 letter-spacing: 0.1em;
-                text-transform: uppercase;
                 padding: 2px var(--space-2);
                 border: 1px solid var(--neon-g);
                 color: var(--neon-g);
@@ -96,14 +100,14 @@ export const styles = css`
         .catalog-sticky {
             position: sticky;
             top: calc(var(--header-height) * 2);
-            z-index: 20;
+            z-index: var(--z-sticky);
             background: color-mix(in hsl, var(--background) 94%, transparent);
             backdrop-filter: blur(16px);
             -webkit-backdrop-filter: blur(16px);
-            border-bottom: 1px solid color-mix(in hsl, var(--game-primary, var(--neon-c)) 40%, transparent);
+            border-bottom: 1px solid color-mix(in hsl, ${gamePrimary} 40%, transparent);
             box-shadow:
-                0 1px 0 color-mix(in hsl, var(--game-primary, var(--neon-c)) 25%, transparent),
-                0 6px 32px color-mix(in hsl, var(--game-primary, var(--neon-c)) 16%, transparent),
+                0 1px 0 color-mix(in hsl, ${gamePrimary} 25%, transparent),
+                0 6px 32px color-mix(in hsl, ${gamePrimary} 16%, transparent),
                 0 20px 60px color-mix(in hsl, var(--background) 55%, transparent);
             transition:
                 width var(--speed-3) cubic-bezier(0.22, 1, 0.36, 1),
@@ -177,16 +181,15 @@ export const styles = css`
         }
 
         .count__label {
+            padding-left: var(--space-1);
             color: var(--color);
             opacity: 0.4;
         }
 
         .catalog-count {
             flex-shrink: 0;
-            font-family: var(--header-font);
-            font-size: var(--text-xs);
+            ${labelFont}
             letter-spacing: 0.08em;
-            text-transform: uppercase;
             white-space: nowrap;
             padding-left: var(--space-2);
         }
@@ -240,7 +243,7 @@ export const styles = css`
             top: calc(100% + 4px);
             left: 0;
             right: 0;
-            z-index: 50;
+            z-index: var(--z-sticky);
             list-style: none;
             background: color-mix(in hsl, var(--background) 96%, var(--neon-c));
             border: 1px solid color-mix(in hsl, var(--neon-c) 40%, transparent);
@@ -314,10 +317,7 @@ export const styles = css`
             display: inline-flex;
             align-items: center;
             gap: 0.3em;
-            font-family: var(--header-font);
-            font-size: var(--text-xs);
-            letter-spacing: 0.06em;
-            text-transform: uppercase;
+            ${labelFont}
             padding: var(--space-1) var(--space-2);
             border: 1px solid var(--border);
             background: transparent;
@@ -369,9 +369,7 @@ export const styles = css`
         }
 
         .catalog-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: var(--space-3);
+            --grid-cols: 3;
             padding: var(--space-4) 0 var(--space-3);
         }
 
@@ -386,14 +384,14 @@ export const styles = css`
         /* ── Responsive Breakpoints ── */
 
         /* md: Tablets (768–1023px) */
-        @media (max-width: ${bp.md}px) {
+        @media ${mq.mdDown} {
             .game-hero {
                 padding-bottom: var(--space-5);
             }
         }
 
         /* sm: Large phones / small tablets (541–767px) */
-        @media (max-width: ${bp.sm}px) {
+        @media ${mq.smDown} {
             .game-hero {
                 padding-bottom: var(--space-4);
             }
@@ -408,22 +406,8 @@ export const styles = css`
             }
         }
 
-        /* 2-col: narrow tablets / large phones (≤849px) */
-        @media (max-width: ${bp.grid2}px) {
-            .catalog-grid {
-                grid-template-columns: repeat(2, 1fr);
-            }
-        }
-
-        /* 1-col: phones (≤540px) */
-        @media (max-width: ${bp.grid1}px) {
-            .catalog-grid {
-                grid-template-columns: 1fr;
-            }
-        }
-
         /* xs: Mobile phones (≤480px) */
-        @media (max-width: ${bp.xs}px) {
+        @media ${mq.xsDown} {
             .game-hero {
                 padding-bottom: var(--space-3);
                 gap: var(--space-1);
@@ -445,17 +429,16 @@ export const styles = css`
 
             .catalog-count {
                 order: 1;
-                flex: 1;
+            }
+
+            ui-search {
+                order: 2;
             }
 
             .sort-bar {
                 order: 3;
-                flex-wrap: nowrap;
-            }
-
-            .catalog-search-wrap {
-                order: 2;
                 flex-basis: 100%;
+                flex-wrap: nowrap;
             }
 
             .filter-group__label {
@@ -464,7 +447,7 @@ export const styles = css`
         }
 
         /* ── Collapsed pill — tablet + mobile only ── */
-        @media (max-width: ${bp.md}px) {
+        @media ${mq.mdDown} {
             /* Collapsed: pill only — width is set via JS inline style (pixel value)
                so the width → 100% transition has two concrete lengths to interpolate */
             .catalog-sticky.is-stuck:not(.is-expanded) {
@@ -537,18 +520,16 @@ export const styles = css`
 
             /* Pill hover glow */
             .catalog-sticky.is-stuck:not(.is-expanded):hover {
-                border-color: color-mix(in hsl, var(--game-primary, var(--neon-c)) 60%, transparent);
+                border-color: color-mix(in hsl, ${gamePrimary} 60%, transparent);
                 box-shadow:
-                    0 0 12px color-mix(in hsl, var(--game-primary, var(--neon-c)) 25%, transparent),
-                    0 6px 32px color-mix(in hsl, var(--game-primary, var(--neon-c)) 16%, transparent);
+                    0 0 12px color-mix(in hsl, ${gamePrimary} 25%, transparent),
+                    0 6px 32px color-mix(in hsl, ${gamePrimary} 16%, transparent);
             }
 
             /* ── Pill internals ── */
             .pill__type {
-                font-family: var(--header-font);
-                font-size: var(--text-xs);
+                ${labelFont}
                 letter-spacing: 0.08em;
-                text-transform: uppercase;
                 color: var(--color);
                 opacity: 0.4;
                 white-space: nowrap;
@@ -580,18 +561,12 @@ export const styles = css`
             }
 
             .pill__count {
-                font-family: var(--header-font);
-                font-size: var(--text-xs);
-                letter-spacing: 0.06em;
-                text-transform: uppercase;
+                ${labelFont}
                 white-space: nowrap;
             }
 
             .pill__sort {
-                font-family: var(--header-font);
-                font-size: var(--text-xs);
-                letter-spacing: 0.06em;
-                text-transform: uppercase;
+                ${labelFont}
                 color: var(--neon-g);
                 text-shadow: var(--glow-g);
                 white-space: nowrap;
@@ -629,28 +604,26 @@ export const styles = css`
         }
 
         .load-more-btn {
-            font-family: var(--header-font);
-            font-size: var(--text-xs);
+            ${labelFont}
             letter-spacing: 0.12em;
-            text-transform: uppercase;
             padding: var(--space-2) var(--space-6);
-            border: 1px solid var(--game-text-color, var(--game-primary, var(--neon-c)));
+            border: 1px solid ${gameColor};
             background: transparent;
-            color: var(--game-text-color, var(--game-primary, var(--neon-c)));
+            color: ${gameColor};
             cursor: pointer;
             box-shadow:
-                0 0 8px color-mix(in hsl, var(--game-text-color, var(--game-primary, var(--neon-c))) 30%, transparent),
-                0 0 24px color-mix(in hsl, var(--game-text-color, var(--game-primary, var(--neon-c))) 12%, transparent);
+                0 0 8px color-mix(in hsl, ${gameColor} 30%, transparent),
+                0 0 24px color-mix(in hsl, ${gameColor} 12%, transparent);
             transition:
                 box-shadow var(--speed),
                 background var(--speed);
 
             &:hover {
-                background: color-mix(in hsl, var(--game-text-color, var(--game-primary, var(--neon-c))) 8%, transparent);
+                background: color-mix(in hsl, ${gameColor} 8%, transparent);
                 box-shadow:
-                    0 0 8px color-mix(in hsl, var(--game-text-color, var(--game-primary, var(--neon-c))) 53%, transparent),
-                    0 0 24px color-mix(in hsl, var(--game-text-color, var(--game-primary, var(--neon-c))) 20%, transparent),
-                    0 0 48px color-mix(in hsl, var(--game-text-color, var(--game-primary, var(--neon-c))) 10%, transparent);
+                    0 0 8px color-mix(in hsl, ${gameColor} 53%, transparent),
+                    0 0 24px color-mix(in hsl, ${gameColor} 20%, transparent),
+                    0 0 48px color-mix(in hsl, ${gameColor} 10%, transparent);
             }
 
             &:disabled {

--- a/src/UI/routes/game/[game]/styles.css.js
+++ b/src/UI/routes/game/[game]/styles.css.js
@@ -54,6 +54,9 @@ export const styles = css`
                 border: 1px solid var(--neon-g);
                 color: var(--neon-g);
                 text-shadow: var(--glow-g);
+                background: color-mix(in hsl, var(--neon-g) 10%, transparent);
+                backdrop-filter: blur(4px);
+                -webkit-backdrop-filter: blur(4px);
             }
 
             h1 {
@@ -99,7 +102,7 @@ export const styles = css`
         /* ── Sticky band (filters + toolbar) ── */
         .catalog-sticky {
             position: sticky;
-            top: calc(var(--header-height) * 2);
+            top: calc(var(--header-height) + var(--space) * 2);
             z-index: var(--z-sticky);
             background: color-mix(in hsl, var(--background) 94%, transparent);
             backdrop-filter: blur(16px);
@@ -133,12 +136,6 @@ export const styles = css`
             border: 1px solid transparent;
         }
 
-        /* Size the search component to fill the flex row like the old input did */
-        ui-search {
-            flex: 1;
-            min-width: 0;
-        }
-
         /* ── Toolbar ── */
         @keyframes toolbar-pulse {
             0% {
@@ -155,12 +152,13 @@ export const styles = css`
         }
 
         #toolbar {
-            display: flex;
+            display: grid;
+            grid-template-columns: auto 1fr auto;
+            grid-template-areas: "count search sort";
             align-items: center;
             gap: var(--space-3);
             padding: var(--space-3) var(--space-4) var(--space-4);
             margin: 0;
-            border: 1px solid color-mix(in hsl, var(--color) 12%, transparent);
             background: color-mix(in hsl, var(--color) 3%, transparent);
             transition:
                 border-color var(--speed-2),
@@ -168,9 +166,23 @@ export const styles = css`
                 box-shadow var(--speed-2);
 
             &:focus-within {
-                border-color: color-mix(in hsl, var(--neon-c) 45%, transparent);
                 background: color-mix(in hsl, var(--neon-c) 3%, transparent);
                 animation: toolbar-pulse var(--speed-2) ease forwards;
+            }
+
+            .catalog-count {
+                grid-area: count;
+                line-height: normal;
+            }
+            ui-search {
+                grid-area: search;
+                min-width: 0;
+            }
+            .sort-bar {
+                grid-area: sort;
+            }
+            .catalog-collapse-btn {
+                grid-area: collapse;
             }
         }
 
@@ -188,10 +200,10 @@ export const styles = css`
 
         .catalog-count {
             flex-shrink: 0;
+            align-self: center;
             ${labelFont}
             letter-spacing: 0.08em;
             white-space: nowrap;
-            padding-left: var(--space-2);
         }
 
         /* ── Search wrap + autocomplete ── */
@@ -309,25 +321,46 @@ export const styles = css`
 
         .sort-bar {
             display: flex;
+            justify-content: flex-end;
             flex-wrap: wrap;
             gap: var(--space-1);
         }
 
+        .sort-bar__label {
+            padding-inline: var(--space-1) var(--space-2);
+            color: var(--color);
+            opacity: 0.4;
+            font-family: var(--header-font);
+            font-size: var(--text-xs);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            white-space: nowrap;
+            align-self: center;
+            line-height: normal;
+
+            @media ${mq.xsDown} {
+                display: none;
+            }
+        }
+
         .sort-bar button {
             display: inline-flex;
+            justify-content: center;
             align-items: center;
-            gap: 0.3em;
             ${labelFont}
             padding: var(--space-1) var(--space-2);
             border: 1px solid var(--border);
-            background: transparent;
+            text-shadow: var(--glow-g);
+            box-shadow: 0 0 12px color-mix(in hsl, var(--neon-g) 20%, transparent);
+            background: color-mix(in hsl, var(--neon-g) 5%, transparent);
+            padding: var(--space-1) var(--space-2);
             color: var(--color);
             cursor: pointer;
             transition:
                 border-color var(--speed),
                 color var(--speed);
 
-            &:hover {
+            &:hover:not(:disabled) {
                 border-color: var(--neon-g);
                 color: var(--neon-g);
             }
@@ -336,18 +369,21 @@ export const styles = css`
                 border-color: var(--neon-g);
                 color: var(--neon-g);
             }
+
+            &:disabled {
+                opacity: 0.3;
+                cursor: not-allowed;
+                border-color: var(--border);
+                color: var(--color);
+            }
         }
 
-        /* fixed-width direction slot — always occupies space, visible only when active */
+        /* direction indicator — hidden when button is inactive */
         .sort-dir {
-            display: inline-block;
-            min-width: 3ch;
-            text-align: center;
-            opacity: 0;
-            transition: opacity var(--speed);
-
+            display: none;
+            font-size: var(--text-sm);
             .sort-bar button.active & {
-                opacity: 1;
+                display: inline-block;
             }
         }
 
@@ -356,7 +392,7 @@ export const styles = css`
             position: relative;
 
             &.is-loading-all {
-                min-height: 320px;
+                min-height: 80vh;
 
                 .catalog-grid {
                     display: none;
@@ -383,30 +419,21 @@ export const styles = css`
 
         /* ── Responsive Breakpoints ── */
 
-        /* md: Tablets (768–1023px) */
+        /* mdDown: tablet and below (<768px) */
         @media ${mq.mdDown} {
             .game-hero {
                 padding-bottom: var(--space-5);
             }
         }
 
-        /* sm: Large phones / small tablets (541–767px) */
+        /* smDown: small phones and below (<576px) */
         @media ${mq.smDown} {
             .game-hero {
                 padding-bottom: var(--space-4);
             }
-
-            #toolbar {
-                flex-wrap: wrap;
-                padding: var(--space-3);
-            }
-
-            .sort-bar {
-                flex-basis: 100%;
-            }
         }
 
-        /* xs: Mobile phones (≤480px) */
+        /* xsDown: extra small phones (<480px) */
         @media ${mq.xsDown} {
             .game-hero {
                 padding-bottom: var(--space-3);
@@ -421,39 +448,31 @@ export const styles = css`
                 }
             }
 
-            #toolbar {
-                flex-wrap: wrap;
-                gap: var(--space-2);
-                padding: var(--space-3);
-            }
-
-            .catalog-count {
-                order: 1;
-            }
-
-            ui-search {
-                order: 2;
-            }
-
-            .sort-bar {
-                order: 3;
-                flex-basis: 100%;
-                flex-wrap: nowrap;
-            }
-
             .filter-group__label {
                 width: 3rem;
             }
         }
 
-        /* ── Collapsed pill — tablet + mobile only ── */
+        /* mdDown: toolbar switches to 2-row grid — search full-width on row 1 */
+        @media ${mq.mdDown} {
+            #toolbar {
+                grid-template-columns: auto 1fr;
+                grid-template-rows: auto auto;
+                grid-template-areas:
+                    "search  search"
+                    "count   sort";
+                padding: var(--space-3);
+            }
+        }
+
+        /* ── Collapsed pill — mdDown only (<768px) ── */
         @media ${mq.mdDown} {
             /* Collapsed: pill only — width is set via JS inline style (pixel value)
                so the width → 100% transition has two concrete lengths to interpolate */
             .catalog-sticky.is-stuck:not(.is-expanded) {
+                top: calc(var(--header-height) * 2);
                 border-radius: 0 0 8px 0;
                 cursor: pointer;
-
                 .marketplace-nav,
                 #toolbar {
                     display: none;
@@ -483,6 +502,18 @@ export const styles = css`
                     display: none;
                 }
 
+                #toolbar {
+                    grid-template-columns: auto 1fr auto auto;
+                    grid-template-areas: "count search sort collapse";
+
+                    @media ${mq.mdDown} {
+                        grid-template-columns: auto 1fr auto;
+                        grid-template-areas:
+                            "search  search   search"
+                            "count   sort     collapse";
+                    }
+                }
+
                 .catalog-collapse-btn {
                     display: flex;
                     align-items: center;
@@ -494,26 +525,17 @@ export const styles = css`
                     border: none;
                     background: transparent;
                     cursor: pointer;
+                    color: var(--neon-g);
+                    transition: color var(--speed);
 
-                    &::before {
-                        content: "";
-                        display: block;
+                    ui-svg {
                         width: 100%;
                         height: 100%;
-                        background-color: var(--neon-g);
-                        -webkit-mask-image: var(--icon-chevron-double);
-                        mask-image: var(--icon-chevron-double);
-                        -webkit-mask-size: contain;
-                        mask-size: contain;
-                        -webkit-mask-repeat: no-repeat;
-                        mask-repeat: no-repeat;
-                        -webkit-mask-position: center;
-                        mask-position: center;
-                        transition: background-color var(--speed);
+                        pointer-events: none;
                     }
 
-                    &:hover::before {
-                        background-color: var(--game-primary, var(--neon-c));
+                    &:hover {
+                        color: var(--game-primary, var(--neon-c));
                     }
                 }
             }
@@ -530,15 +552,28 @@ export const styles = css`
             .pill__type {
                 ${labelFont}
                 letter-spacing: 0.08em;
-                color: var(--color);
-                opacity: 0.4;
                 white-space: nowrap;
                 flex-shrink: 0;
-                transition: opacity var(--speed);
+                border: none;
+                padding: var(--space-1) var(--space-2);
+                background: transparent;
+                color: color-mix(in hsl, var(--color) 50%, transparent);
+                cursor: pointer;
+                transition:
+                    border-color var(--speed),
+                    color var(--speed),
+                    background var(--speed),
+                    box-shadow var(--speed);
+
+                &:hover {
+                    border-color: var(--neon-c);
+                    color: var(--neon-c);
+                }
 
                 &.active {
-                    opacity: 1;
-                    color: var(--neon-c);
+                    color: var(--filter-accent, var(--accent-info));
+                    background: color-mix(in hsl, var(--filter-accent, var(--accent-info)) 6%, transparent);
+                    box-shadow: 0 0 12px color-mix(in hsl, var(--filter-accent, var(--accent-info)) 25%, transparent);
                 }
             }
 
@@ -550,9 +585,14 @@ export const styles = css`
                 background: var(--pill-rarity-color, var(--color));
                 box-shadow: none;
                 opacity: 0.2;
+                cursor: pointer;
                 transition:
                     box-shadow var(--speed),
                     opacity var(--speed);
+
+                &:hover {
+                    opacity: 0.6;
+                }
 
                 &.active {
                     opacity: 1;
@@ -570,20 +610,54 @@ export const styles = css`
                 color: var(--neon-g);
                 text-shadow: var(--glow-g);
                 white-space: nowrap;
+                box-shadow: 0 0 12px color-mix(in hsl, var(--filter-accent, var(--accent-info)) 25%, transparent);
+                background: color-mix(in hsl, var(--filter-accent, var(--accent-info)) 6%, transparent);
+                padding: var(--space-1);
             }
 
             .pill__search {
                 flex-shrink: 0;
-                color: var(--color);
-                opacity: 0.4;
+                color: var(--neon-g);
+                opacity: 0.6;
                 line-height: 0;
+                cursor: pointer;
                 transition:
                     color var(--speed),
                     opacity var(--speed);
+                padding: var(--space-1);
+                border: none;
+                border-radius: 999px;
+                background: color-mix(in hsl, var(--filter-accent, var(--accent-info)) 6%, transparent);
+                box-shadow: 0 0 12px color-mix(in hsl, var(--filter-accent, var(--accent-info)) 25%, transparent);
+
+                ui-svg {
+                    width: 16px;
+                    height: 16px;
+                    pointer-events: none;
+                    filter: none;
+                    transition: filter var(--speed);
+                }
+
+                &:hover {
+                    color: var(--neon-c);
+                    opacity: 0.8;
+
+                    ui-svg {
+                        filter: drop-shadow(0 0 4px color-mix(in hsl, var(--neon-c) 60%, transparent));
+                    }
+                }
+
+                &:active {
+                    opacity: 0.5;
+                }
 
                 &.active {
                     color: var(--neon-c);
                     opacity: 1;
+
+                    ui-svg {
+                        filter: drop-shadow(0 0 4px color-mix(in hsl, var(--neon-c) 80%, transparent)) drop-shadow(0 0 10px color-mix(in hsl, var(--neon-c) 40%, transparent));
+                    }
                 }
             }
 
@@ -594,6 +668,20 @@ export const styles = css`
                 background: color-mix(in hsl, var(--color) 20%, transparent);
                 align-self: center;
             }
+        }
+
+        /* ── Empty state ── */
+        .catalog-empty {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 160px;
+            font-family: var(--header-font);
+            font-size: var(--text-sm);
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--color);
+            opacity: 0.35;
         }
 
         /* ── Load More ── */

--- a/src/UI/routes/game/[game]/template.js
+++ b/src/UI/routes/game/[game]/template.js
@@ -24,14 +24,17 @@ export const template = html`
                 <span class="pill__divider"></span>
                 <span class="pill__rarity-dot" id="pill-rarity-dot"></span>
                 <span class="pill__divider"></span>
-                <span class="pill__count" id="pill-count"><span class="count__num" id="pill-count-num"></span><span class="count__label"> Items</span></span>
+                <span class="pill__count" id="pill-count">
+                    <span class="count__num" id="pill-count-num"></span>
+                    <span class="count__label">Items</span>
+                </span>
                 <span class="pill__divider"></span>
                 <span class="pill__sort" id="pill-sort"></span>
                 <span class="pill__divider"></span>
                 <span class="pill__search" id="pill-search" aria-label="Search">
                     <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                        <circle cx="6.5" cy="6.5" r="4.5" stroke="currentColor" stroke-width="1.5"/>
-                        <line x1="10" y1="10" x2="14" y2="14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                        <circle cx="6.5" cy="6.5" r="4.5" stroke="currentColor" stroke-width="1.5" />
+                        <line x1="10" y1="10" x2="14" y2="14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
                     </svg>
                 </span>
             </div>
@@ -45,7 +48,10 @@ export const template = html`
             </nav>
 
             <div class="catalog-toolbar" id="toolbar">
-                <span class="catalog-count" id="count"><span class="count__num" id="count-num"></span><span class="count__label"> Items</span></span>
+                <span class="catalog-count" id="count">
+                    <span class="count__num" id="count-num"></span>
+                    <span class="count__label">Items</span>
+                </span>
                 <ui-search id="search" placeholder="Search items…"></ui-search>
                 <div class="sort-bar" id="sort"></div>
                 <button class="catalog-collapse-btn" id="catalog-collapse" aria-label="Collapse filters"></button>
@@ -53,7 +59,7 @@ export const template = html`
         </div>
 
         <div class="catalog-grid-wrap" id="items-wrap">
-            <div class="catalog-grid" id="items"></div>
+            <div class="catalog-grid grid" id="items"></div>
             <ui-loader aria-live="polite" aria-label="Loading items">Loading…</ui-loader>
         </div>
 

--- a/src/UI/routes/game/[game]/template.js
+++ b/src/UI/routes/game/[game]/template.js
@@ -4,6 +4,7 @@ import "/UI/components/item/index.js"
 import "/UI/components/loader/index.js"
 import "/UI/components/search/index.js"
 import "/UI/components/filter-group/index.js"
+import "/UI/components/svg/index.js"
 import { html } from "/core/UI.js"
 import styles from "./styles.css.js"
 
@@ -19,23 +20,20 @@ export const template = html`
 
         <div class="sticky-sentinel"></div>
         <div class="catalog-sticky">
-            <div class="catalog-pill" id="catalog-pill" aria-label="Open filters">
-                <span class="pill__type" id="pill-type">All</span>
-                <span class="pill__divider"></span>
-                <span class="pill__rarity-dot" id="pill-rarity-dot"></span>
-                <span class="pill__divider"></span>
+            <div class="catalog-pill" id="catalog-pill" role="group" aria-label="Filters summary">
                 <span class="pill__count" id="pill-count">
                     <span class="count__num" id="pill-count-num"></span>
                     <span class="count__label">Items</span>
                 </span>
                 <span class="pill__divider"></span>
+                <button class="pill__type active" id="pill-type" aria-label="Filter by type">All</button>
+                <span class="pill__divider"></span>
+                <span class="pill__rarity-dot" id="pill-rarity-dot" role="button" tabindex="0" aria-label="Filter by rarity"></span>
+                <span class="pill__divider"></span>
                 <span class="pill__sort" id="pill-sort"></span>
                 <span class="pill__divider"></span>
                 <span class="pill__search" id="pill-search" aria-label="Search">
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                        <circle cx="6.5" cy="6.5" r="4.5" stroke="currentColor" stroke-width="1.5" />
-                        <line x1="10" y1="10" x2="14" y2="14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
-                    </svg>
+                    <ui-svg data-src="/images/icons/search.svg"></ui-svg>
                 </span>
             </div>
             <nav class="marketplace-nav">
@@ -54,12 +52,15 @@ export const template = html`
                 </span>
                 <ui-search id="search" placeholder="Search items…"></ui-search>
                 <div class="sort-bar" id="sort"></div>
-                <button class="catalog-collapse-btn" id="catalog-collapse" aria-label="Collapse filters"></button>
+                <button class="catalog-collapse-btn" id="catalog-collapse" aria-label="Collapse filters">
+                    <ui-svg data-src="/images/icons/chevron-double-left.svg"></ui-svg>
+                </button>
             </div>
         </div>
 
         <div class="catalog-grid-wrap" id="items-wrap">
             <div class="catalog-grid grid" id="items"></div>
+            <p class="catalog-empty" id="items-empty" hidden></p>
             <ui-loader aria-live="polite" aria-label="Loading items">Loading…</ui-loader>
         </div>
 

--- a/src/UI/routes/item/[item]/styles.css.js
+++ b/src/UI/routes/item/[item]/styles.css.js
@@ -2,8 +2,8 @@ import fieldset from "/UI/css/elements/fieldset.css.js"
 import input from "/UI/css/elements/input.css.js"
 import radioItem from "/UI/css/elements/radio-item.css.js"
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
-import grid from "/UI/css/elements/grid.css.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
+import grid from "/UI/css/layout/grid.css.js"
 
 export const styles = css`
     ${grid}

--- a/src/UI/routes/item/[item]/styles.css.js
+++ b/src/UI/routes/item/[item]/styles.css.js
@@ -2,9 +2,11 @@ import fieldset from "/UI/css/elements/fieldset.css.js"
 import input from "/UI/css/elements/input.css.js"
 import radioItem from "/UI/css/elements/radio-item.css.js"
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
+import grid from "/UI/css/elements/grid.css.js"
 
 export const styles = css`
+    ${grid}
     ${fieldset}
     ${input}
     ${radioItem}
@@ -12,17 +14,14 @@ export const styles = css`
         --item-rarity-color: var(--color-accent, #888);
 
         #item {
-            display: grid;
-            grid-template-columns: 260px 1fr;
+            --sidebar-width: 260px;
             grid-template-areas:
                 "breadcrumb breadcrumb"
                 "image header"
                 "image main"
                 "footer footer";
-            gap: var(--space-3);
 
-            @media (max-width: ${bp.sm}px) {
-                grid-template-columns: 1fr;
+            @media ${mq.sm} {
                 grid-template-areas:
                     "breadcrumb"
                     "image"

--- a/src/UI/routes/item/[item]/template.js
+++ b/src/UI/routes/item/[item]/template.js
@@ -10,7 +10,7 @@ import styles from "./styles.css.js"
 export const template = html`
     ${styles}
     <layout-main>
-        <form id="item">
+        <form id="item" class="grid--sidebar">
             <nav id="breadcrumb" style="grid-area: breadcrumb;">
                 <a is="ui-a" id="back-link"></a>
                 <span id="breadcrumb-sep"> › </span>

--- a/src/UI/routes/pools/styles.css.js
+++ b/src/UI/routes/pools/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 
 export const styles = css`
     /* ── Keyframes at top level (never nest @keyframes inside a selector) ── */

--- a/src/UI/routes/pools/styles.css.js
+++ b/src/UI/routes/pools/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
 
 export const styles = css`
     /* ── Keyframes at top level (never nest @keyframes inside a selector) ── */
@@ -427,7 +427,7 @@ export const styles = css`
         }
 
         /* ── Responsive: md (≤1023px) ── */
-        @media (max-width: ${bp.md}px) {
+        @media ${mq.mdDown} {
             --col-rate: 0px;
 
             .th-rate {
@@ -442,7 +442,7 @@ export const styles = css`
         }
 
         /* ── Responsive: sm (≤767px) ── */
-        @media (max-width: ${bp.sm}px) {
+        @media ${mq.smDown} {
             .table-header {
                 display: none;
             }

--- a/src/UI/routes/profile/styles.css.js
+++ b/src/UI/routes/profile/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
 
 export const styles = css`
     :host {
@@ -107,7 +107,7 @@ export const styles = css`
             bottom: 0;
             left: var(--page-pad);
             transform: translateY(50%);
-            z-index: 1;
+            z-index: var(--z-base);
 
             ui-identicon {
                 display: block;
@@ -149,7 +149,7 @@ export const styles = css`
             display: none;
             position: fixed;
             inset: 0;
-            z-index: 1100;
+            z-index: var(--z-picker-backdrop);
             background: color-mix(in hsl, var(--background) 40%, transparent);
             backdrop-filter: blur(var(--blur-md));
             -webkit-backdrop-filter: blur(var(--blur-md));
@@ -167,7 +167,7 @@ export const styles = css`
             left: 0;
             right: 0;
             height: calc(var(--avatar-size) * 2 + var(--space-9) + var(--space-6));
-            z-index: 1200;
+            z-index: var(--z-picker);
             flex-direction: column;
             overflow: hidden;
             border-top: var(--border-width) solid color-mix(in hsl, var(--neon-c) 25%, transparent);
@@ -792,7 +792,7 @@ export const styles = css`
         }
 
         /* ── Responsive — mirrors game-hero breakpoints ── */
-        @media (max-width: ${bp.md}px) {
+        @media ${mq.mdDown} {
             .profile-hero {
                 padding-bottom: calc(var(--space-5) + clamp(4rem, 9vw, 7rem));
             }
@@ -800,7 +800,7 @@ export const styles = css`
             .profile-hero__gradient { --grid-v: 5.5%; }
         }
 
-        @media (max-width: ${bp.sm}px) {
+        @media ${mq.smDown} {
             .profile-hero {
                 padding-bottom: calc(var(--space-4) + clamp(3.5rem, 8vw, 6rem));
             }
@@ -817,7 +817,7 @@ export const styles = css`
             .profile-hero__gradient { --grid-v: 7.5%; }
         }
 
-        @media (max-width: ${bp.xs}px) {
+        @media ${mq.xsDown} {
             .profile-hero {
                 padding-bottom: calc(var(--space-3) + clamp(3rem, 7vw, 4.5rem));
             }

--- a/src/UI/routes/profile/styles.css.js
+++ b/src/UI/routes/profile/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 
 export const styles = css`
     :host {

--- a/src/UI/routes/showcase/index.js
+++ b/src/UI/routes/showcase/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable curly */
 import template from "./template.js"
 import Route from "/core/UI/Route.js"
 import stories from "./stories/index.js"
@@ -13,6 +14,7 @@ export class SHOWCASE extends Route {
     onconnect() {
         this._renderSidebar()
         this._renderCanvas()
+        this._updateSidebarActive()
         this.listen(globalThis, "hashchange", this._onHashChange)
     }
 
@@ -47,7 +49,14 @@ export class SHOWCASE extends Route {
     }
 
     _updateSidebarActive(current = this._currentGroup()) {
-        for (const item of this.shadowRoot.querySelectorAll(".nav-item")) item.classList.toggle("active", item.textContent === current.name)
+        const sidebar = this.shadowRoot.getElementById("sidebar")
+        for (const item of sidebar.querySelectorAll(".nav-item")) {
+            const isActive = item.textContent === current.name
+            item.classList.toggle("active", isActive)
+            if (isActive && sidebar.scrollWidth > sidebar.clientWidth) {
+                item.scrollIntoView({ block: "nearest", inline: "center", behavior: "smooth" })
+            }
+        }
     }
 
     _renderCanvas(group = this._currentGroup()) {

--- a/src/UI/routes/showcase/index.js
+++ b/src/UI/routes/showcase/index.js
@@ -60,7 +60,7 @@ export class SHOWCASE extends Route {
         canvas.appendChild(title)
 
         const grid = document.createElement("div")
-        grid.className = "stories-grid"
+        grid.className = "stories-grid grid--fluid"
 
         for (const story of group.stories) {
             const card = document.createElement("div")

--- a/src/UI/routes/showcase/stories/container.js
+++ b/src/UI/routes/showcase/stories/container.js
@@ -1,0 +1,31 @@
+const CONTAINERS = [
+    { name: ".container-form", var: "--container-form", px: "480px" },
+    { name: ".container-sm", var: "--container-sm", px: "540px" },
+    { name: ".container-md", var: "--container-md", px: "720px" },
+    { name: ".container-lg", var: "--container-lg", px: "960px" },
+    { name: ".container-xl", var: "--container-xl", px: "1140px" },
+    { name: ".container-xxl", var: "--container-xxl", px: "1320px" },
+    { name: ".container-fluid", var: null, px: "100%" }
+]
+
+function makeRow({ name, var: cssVar, px }) {
+    const maxWidth = cssVar ? `var(${cssVar}, ${px})` : "none"
+    return `<div class="sc-row">
+  <div class="sc-bar" style="max-width: ${maxWidth}">
+    <span class="sc-label">${name}</span>
+    <span class="sc-meta">${cssVar ? `${cssVar} · ` : ""}${px}</span>
+  </div>
+</div>`
+}
+
+export default {
+    name: "Container",
+
+    stories: [
+        {
+            name: "All Containers",
+            wide: true,
+            code: CONTAINERS.map(makeRow).join("\n")
+        }
+    ]
+}

--- a/src/UI/routes/showcase/stories/grid.js
+++ b/src/UI/routes/showcase/stories/grid.js
@@ -1,0 +1,155 @@
+export default {
+    name: "Grid",
+
+    stories: [
+        // ── Five grid tiers ────────────────────────────────────────────────────
+        {
+            name: "Five Grid Tiers",
+            wide: true,
+            code: `<div class="sg-tiers">
+  <div class="sg-tier sg-tier--xs">
+    <div class="sg-col">xs · always</div>
+    <div class="sg-col">xs · always</div>
+    <div class="sg-col">xs · always</div>
+  </div>
+  <div class="sg-tier sg-tier--sm">
+    <div class="sg-col">sm · ≥576px</div>
+    <div class="sg-col">sm · ≥576px</div>
+    <div class="sg-col">sm · ≥576px</div>
+  </div>
+  <div class="sg-tier sg-tier--md">
+    <div class="sg-col">md · ≥768px</div>
+    <div class="sg-col">md · ≥768px</div>
+    <div class="sg-col">md · ≥768px</div>
+  </div>
+  <div class="sg-tier sg-tier--lg">
+    <div class="sg-col">lg · ≥992px</div>
+    <div class="sg-col">lg · ≥992px</div>
+    <div class="sg-col">lg · ≥992px</div>
+  </div>
+  <div class="sg-tier sg-tier--xl">
+    <div class="sg-col">xl · ≥1200px</div>
+    <div class="sg-col">xl · ≥1200px</div>
+    <div class="sg-col">xl · ≥1200px</div>
+  </div>
+</div>`,
+        },
+
+        // ── Three equal columns ────────────────────────────────────────────────
+        {
+            name: "Three Equal Columns",
+            wide: true,
+            code: `<div class="sg-grid" style="--grid-cols: 3">
+  <div class="sg-col">1fr</div>
+  <div class="sg-col">1fr</div>
+  <div class="sg-col">1fr</div>
+</div>`,
+        },
+
+        // ── Three unequal columns ──────────────────────────────────────────────
+        {
+            name: "Three Unequal Columns",
+            wide: true,
+            code: `<div class="sg-grid-custom" style="grid-template-columns: 1fr 2fr 1fr">
+  <div class="sg-col">1fr</div>
+  <div class="sg-col">2fr</div>
+  <div class="sg-col">1fr</div>
+</div>`,
+        },
+
+        // ── Two columns ────────────────────────────────────────────────────────
+        {
+            name: "Two Columns",
+            wide: true,
+            code: `<div class="sg-grid-custom" style="grid-template-columns: 2fr 1fr">
+  <div class="sg-col">2fr</div>
+  <div class="sg-col">1fr</div>
+</div>`,
+        },
+
+        // ── Fluid ──────────────────────────────────────────────────────────────
+        {
+            name: ".grid--fluid — Auto-fill Columns",
+            wide: true,
+            code: `<div class="sg-grid--fluid">
+  <div class="sg-col">1</div>
+  <div class="sg-col">2</div>
+  <div class="sg-col">3</div>
+  <div class="sg-col">4</div>
+  <div class="sg-col">5</div>
+</div>`,
+        },
+        {
+            name: ".grid--fluid — Narrow Min Width (8rem)",
+            wide: true,
+            code: `<div class="sg-grid--fluid" style="--grid-min: 8rem">
+  <div class="sg-col">1</div>
+  <div class="sg-col">2</div>
+  <div class="sg-col">3</div>
+  <div class="sg-col">4</div>
+  <div class="sg-col">5</div>
+  <div class="sg-col">6</div>
+  <div class="sg-col">7</div>
+  <div class="sg-col">8</div>
+</div>`,
+        },
+
+        // ── Sidebar ────────────────────────────────────────────────────────────
+        {
+            name: ".grid--sidebar — Default (15rem)",
+            wide: true,
+            code: `<div class="sg-grid--sidebar">
+  <aside class="sg-col sg-col--sidebar">Sidebar</aside>
+  <main class="sg-col sg-col--main">Main content</main>
+</div>`,
+        },
+        {
+            name: ".grid--sidebar — Wide (20rem)",
+            wide: true,
+            code: `<div class="sg-grid--sidebar" style="--sidebar-width: 20rem">
+  <aside class="sg-col sg-col--sidebar">Wide Sidebar</aside>
+  <main class="sg-col sg-col--main">Main content</main>
+</div>`,
+        },
+
+        // ── Table ──────────────────────────────────────────────────────────────
+        {
+            name: ".grid--table — Fixed Column Contract",
+            wide: true,
+            code: `<div class="sg-table-wrap">
+  <div class="sg-grid--table sg-table-header" style="--table-cols: 2rem 1fr 6rem 6rem">
+    <span></span>
+    <span>Item</span>
+    <span>Price</span>
+    <span>Stock</span>
+  </div>
+  <div class="sg-grid--table sg-table-row" style="--table-cols: 2rem 1fr 6rem 6rem">
+    <span>1</span><span>AK-7 Neon Keyboard</span><span>$129.99</span><span>42</span>
+  </div>
+  <div class="sg-grid--table sg-table-row" style="--table-cols: 2rem 1fr 6rem 6rem">
+    <span>2</span><span>Hyper Glide Mouse Pad XL</span><span>$39.99</span><span>7</span>
+  </div>
+  <div class="sg-grid--table sg-table-row" style="--table-cols: 2rem 1fr 6rem 6rem">
+    <span>3</span><span>RGB Hub 7-Port USB-C</span><span>$24.99</span><span>0</span>
+  </div>
+</div>`,
+        },
+
+        // ── Breakpoint reference ───────────────────────────────────────────────
+        {
+            name: "Breakpoint Reference",
+            wide: true,
+            code: `<div class="sg-bp-table">
+  <div class="sg-bp-row sg-bp-row--header">
+    <span>Name</span><span>px</span><span>mq.*Up</span><span>mq.*Down</span><span>mq.*Only</span>
+  </div>
+  <div class="sg-bp-row"><span>xs</span><span>480</span><span>—</span><span>xsDown</span><span>xsOnly</span></div>
+  <div class="sg-bp-row"><span>sm</span><span>576</span><span>smUp</span><span>smDown</span><span>smOnly</span></div>
+  <div class="sg-bp-row"><span>md</span><span>768</span><span>mdUp</span><span>mdDown</span><span>mdOnly</span></div>
+  <div class="sg-bp-row"><span>lg</span><span>992</span><span>lgUp</span><span>lgDown</span><span>lgOnly</span></div>
+  <div class="sg-bp-row"><span>xl</span><span>1200</span><span>xlUp</span><span>xlDown</span><span>xlOnly</span></div>
+  <div class="sg-bp-row"><span>xxl</span><span>1400</span><span>xxlUp</span><span>xxlDown</span><span>—</span></div>
+</div>`,
+        },
+    ],
+}

--- a/src/UI/routes/showcase/stories/index.js
+++ b/src/UI/routes/showcase/stories/index.js
@@ -1,3 +1,5 @@
+import grid from "./grid.js"
+import container from "./container.js"
 import logo from "./logo.js"
 import button from "./button.js"
 import loader from "./loader.js"
@@ -17,4 +19,4 @@ import items from "./items.js"
 import cameraQR from "./camera-qr.js"
 import wave from "./wave.js"
 
-export default [logo, button, loader, icon, identicon, fiat, svg, modal, select, picker, a, locales, typography, themes, notifications, items, cameraQR, wave]
+export default [logo, button, loader, icon, identicon, fiat, svg, modal, select, picker, a, locales, typography, themes, notifications, items, cameraQR, wave, grid, container]

--- a/src/UI/routes/showcase/styles.css.js
+++ b/src/UI/routes/showcase/styles.css.js
@@ -1,15 +1,25 @@
 import { css } from "/core/UI.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 import typographyStyles from "./stories/typography.css.js"
-import grid from "/UI/css/elements/grid.css.js"
+import grid from "/UI/css/layout/grid.css.js"
 
 export const styles = css`
     ${grid}
     :host {
+        --content-width: 100%;
+
         .showcase {
-            --sidebar-width: 14rem;
+            --sidebar-width: 16rem;
             height: calc(100vh - var(--header-height) - var(--footer-height) - var(--space-6));
             overflow: hidden;
             border: var(--border);
+
+            /* stack sidebar above canvas below lg */
+            @media ${mq.lgDown} {
+                grid-template-columns: 1fr;
+                grid-template-rows: auto 1fr;
+                height: calc(100vh - var(--header-height) - var(--footer-height) - var(--space-6));
+            }
         }
 
         #sidebar {
@@ -18,6 +28,21 @@ export const styles = css`
             padding: var(--space-2) 0;
             display: flex;
             flex-direction: column;
+
+            /* compact horizontal pill bar below lg */
+            @media ${mq.lgDown} {
+                flex-direction: row;
+                align-items: center;
+                overflow-x: auto;
+                overflow-y: hidden;
+                border-right: none;
+                border-bottom: var(--border);
+                padding: var(--space-1) var(--space-2);
+                gap: var(--space-1);
+                scrollbar-width: none;
+
+                &::-webkit-scrollbar { display: none; }
+            }
 
             .nav-group {
                 padding: var(--space) var(--space-3) var(--space-1);
@@ -28,6 +53,8 @@ export const styles = css`
                 text-shadow: 0 0 8px color-mix(in srgb, var(--neon-c) 60%, transparent);
                 opacity: 0.85;
                 font-family: var(--header-font);
+
+                @media ${mq.lgDown} { display: none; }
             }
 
             .nav-item {
@@ -44,17 +71,35 @@ export const styles = css`
                 transition:
                     opacity var(--speed) ease-in-out,
                     color var(--speed) ease-in-out,
-                    border-color var(--speed) ease-in-out;
+                    border-color var(--speed) ease-in-out,
+                    background var(--speed) ease-in-out;
 
-                &:hover {
-                    opacity: 0.8;
-                }
+                &:hover { opacity: 0.8; }
 
                 &.active {
                     opacity: 1;
                     border-left-color: var(--color-accent);
                     color: var(--color-accent);
                     text-shadow: var(--section-label-shadow, none);
+                }
+
+                /* pill style when horizontal */
+                @media ${mq.lgDown} {
+                    flex-shrink: 0;
+                    border-left: none;
+                    border: var(--border-width) solid transparent;
+                    padding: var(--space-1) var(--space-2);
+                    opacity: 0.55;
+                    white-space: nowrap;
+
+                    &:hover { opacity: 1; }
+
+                    &.active {
+                        opacity: 1;
+                        background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+                        border-color: color-mix(in srgb, var(--color-accent) 50%, transparent);
+                        text-shadow: none;
+                    }
                 }
             }
         }
@@ -257,6 +302,150 @@ export const styles = css`
                 }
             }
         }
+    }
+
+    /* ── Grid story helpers ──────────────────────────────────────────────── */
+    .sg-grid        { display: grid; grid-template-columns: repeat(var(--grid-cols, 3), 1fr); gap: var(--grid-gap, var(--space-3)); width: 100%; }
+    .sg-grid--fluid { display: grid; grid-template-columns: repeat(auto-fill, minmax(var(--grid-min, 16rem), 1fr)); gap: var(--grid-gap, var(--space-3)); width: 100%; }
+    .sg-grid--sidebar { display: grid; grid-template-columns: var(--sidebar-width, 15rem) 1fr; gap: var(--grid-gap, var(--space-3)); width: 100%; }
+    .sg-grid--table { display: grid; grid-template-columns: var(--table-cols); align-items: center; width: 100%; }
+
+    /* arbitrary template-columns — for unequal / two-column demos */
+    .sg-grid-custom { display: grid; gap: var(--grid-gap, var(--space-3)); width: 100%; }
+
+    /* responsive tier demos — stacked by default, switch to 3-col at each breakpoint */
+    .sg-tiers { display: flex; flex-direction: column; gap: var(--space-2); width: 100%; }
+
+    .sg-tier {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: var(--space-3);
+        width: 100%;
+    }
+    .sg-tier--xs                          { grid-template-columns: repeat(3, 1fr); }
+    @media ${mq.smUp}  { .sg-tier--sm  { grid-template-columns: repeat(3, 1fr); } }
+    @media ${mq.mdUp}  { .sg-tier--md  { grid-template-columns: repeat(3, 1fr); } }
+    @media ${mq.lgUp}  { .sg-tier--lg  { grid-template-columns: repeat(3, 1fr); } }
+    @media ${mq.xlUp}  { .sg-tier--xl  { grid-template-columns: repeat(3, 1fr); } }
+    @media ${mq.xxlUp} { .sg-tier--xxl { grid-template-columns: repeat(3, 1fr); } }
+
+    .sg-col {
+        background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+        border: 1px solid color-mix(in srgb, var(--color-accent) 35%, transparent);
+        color: var(--color-accent);
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        padding: var(--space-2) var(--space-3);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 3rem;
+    }
+
+    .sg-col--sidebar { background: color-mix(in srgb, var(--neon-c) 12%, transparent); border-color: color-mix(in srgb, var(--neon-c) 35%, transparent); color: var(--neon-c); }
+    .sg-col--main   { background: color-mix(in srgb, var(--neon-g) 10%, transparent); border-color: color-mix(in srgb, var(--neon-g) 30%, transparent); color: var(--neon-g); justify-content: flex-start; }
+
+    .sg-table-wrap { display: flex; flex-direction: column; gap: 0; border: var(--border); width: 100%; }
+
+    .sg-table-header {
+        padding: var(--space) var(--space-2);
+        background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-accent);
+        gap: var(--space-2);
+    }
+
+    .sg-table-row {
+        padding: var(--space) var(--space-2);
+        font-size: var(--text-sm);
+        border-top: var(--border);
+        color: var(--color);
+        gap: var(--space-2);
+
+        &:hover { background: color-mix(in srgb, var(--color) 4%, transparent); }
+    }
+
+    .sg-bp-table { display: flex; flex-direction: column; gap: 0; border: var(--border); font-size: var(--text-sm); }
+
+    .sg-bp-row {
+        display: grid;
+        grid-template-columns: 4rem 4rem 1fr 1fr 1fr;
+        gap: var(--space-2);
+        padding: var(--space) var(--space-3);
+        border-top: var(--border);
+        color: var(--color);
+
+        &:first-child { border-top: none; }
+
+        span:first-child {
+            font-family: var(--header-font);
+            font-weight: 700;
+            color: var(--color-accent);
+        }
+    }
+
+    /* ── Container story helpers ─────────────────────────────────────────── */
+    .story-preview:has(.sc-row) {
+        flex-direction: column;
+        align-items: stretch;
+        gap: var(--space-3);
+    }
+
+    .sc-row {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+    }
+
+    .sc-bar {
+        width: 100%;
+        margin-inline: auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-2);
+        padding: var(--space-2) var(--space-3);
+        background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+        border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
+        border-left: 3px solid var(--color-accent);
+        min-height: 2.75rem;
+        box-sizing: border-box;
+    }
+
+    .sc-label {
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-accent);
+        white-space: nowrap;
+    }
+
+    .sc-meta {
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.06em;
+        color: var(--color);
+        opacity: 0.45;
+        white-space: nowrap;
+    }
+
+    /* ── Breakpoint reference table ──────────────────────────────────────── */
+    .sg-bp-row--header {
+        background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-accent);
+
+        span:first-child { color: var(--color-accent); }
     }
 
     @keyframes glitch-text {

--- a/src/UI/routes/showcase/styles.css.js
+++ b/src/UI/routes/showcase/styles.css.js
@@ -1,11 +1,12 @@
 import { css } from "/core/UI.js"
 import typographyStyles from "./stories/typography.css.js"
+import grid from "/UI/css/elements/grid.css.js"
 
 export const styles = css`
+    ${grid}
     :host {
         .showcase {
-            display: grid;
-            grid-template-columns: 14rem 1fr;
+            --sidebar-width: 14rem;
             height: calc(100vh - var(--header-height) - var(--footer-height) - var(--space-6));
             overflow: hidden;
             border: var(--border);
@@ -97,9 +98,7 @@ export const styles = css`
             }
 
             .stories-grid {
-                display: grid;
-                grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
-                gap: var(--space-3);
+                --grid-min: 16rem;
             }
 
             .story-card {

--- a/src/UI/routes/showcase/template.js
+++ b/src/UI/routes/showcase/template.js
@@ -5,7 +5,7 @@ import { html } from "/core/UI.js"
 export const template = html`
     ${styles}
     <layout-main>
-        <div class="showcase">
+        <div class="showcase grid--sidebar">
             <aside id="sidebar"></aside>
             <section id="canvas"></section>
         </div>

--- a/src/UI/routes/swap/styles.css.js
+++ b/src/UI/routes/swap/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
 
 export const styles = css`
     :host {
@@ -15,7 +15,7 @@ export const styles = css`
 
         ui-card {
             width: 100%;
-            max-width: 480px;
+            max-width: var(--container-form);
         }
 
         /* Swap card grows to fill all remaining vertical space */
@@ -31,7 +31,7 @@ export const styles = css`
             }
         }
 
-        @media (max-width: ${bp.sm}px) {
+        @media ${mq.sm} {
             main {
                 padding: var(--space-sm) 0;
             }

--- a/src/UI/routes/swap/styles.css.js
+++ b/src/UI/routes/swap/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 
 export const styles = css`
     :host {

--- a/src/UI/routes/withdraw/styles.css.js
+++ b/src/UI/routes/withdraw/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { mq } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 import form from "/css/elements/form.css.js"
 import input from "/css/elements/input.css.js"
 

--- a/src/UI/routes/withdraw/styles.css.js
+++ b/src/UI/routes/withdraw/styles.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp } from "/UI/css/breakpoints.js"
+import { mq } from "/UI/css/breakpoints.js"
 import form from "/css/elements/form.css.js"
 import input from "/css/elements/input.css.js"
 
@@ -20,7 +20,7 @@ export const styles = css`
 
         ui-card {
             width: 100%;
-            max-width: 480px;
+            max-width: var(--container-form);
         }
 
         /* Withdraw card grows to fill remaining vertical space */
@@ -43,7 +43,7 @@ export const styles = css`
             }
         }
 
-        @media (max-width: ${bp.sm}px) {
+        @media ${mq.smDown} {
             main {
                 padding: var(--space-sm) 0;
             }

--- a/src/statics/i18n/all.yaml
+++ b/src/statics/i18n/all.yaml
@@ -1,0 +1,18 @@
+ar: الكل
+de: Alle
+en: All
+es: Todos
+fr: Tous
+he: הכל
+hi: सभी
+it: Tutti
+ja: すべて
+ko: 전체
+no: Alle
+pt: Todos
+ru: Все
+th: ทั้งหมด
+ur: سب
+vi: Tất cả
+zh: 全部
+zh-TW: 全部

--- a/src/statics/i18n/noItemsFound.yaml
+++ b/src/statics/i18n/noItemsFound.yaml
@@ -1,0 +1,18 @@
+ar: لا توجد عناصر مطابقة
+de: Keine Artikel gefunden
+en: No items found
+es: No se encontraron artículos
+fr: Aucun article trouvé
+he: לא נמצאו פריטים
+hi: कोई आइटम नहीं मिला
+it: Nessun articolo trovato
+ja: アイテムが見つかりません
+ko: 항목을 찾을 수 없습니다
+no: Ingen gjenstander funnet
+pt: Nenhum item encontrado
+ru: Ничего не найдено
+th: ไม่พบรายการ
+ur: کوئی آئٹم نہیں ملا
+vi: Không tìm thấy mục nào
+zh: 未找到项目
+zh-TW: 未找到項目


### PR DESCRIPTION
## Summary

This branch delivers three related improvements: a consolidated breakpoint and layout utility system shared across the entire UI, a CSS Grid and Container component library with Storybook-style showcase stories, and a comprehensive overhaul of the game route's catalog toolbar, filter controls, and mobile sticky pill.

---

## Breakpoint and Layout Consolidation

The legacy `src/UI/css/breakpoints.js` has been replaced by `src/UI/css/layout/breakpoints.js`, which adds a full set of downward-bound query strings (`mq.mdDown`, `mq.smDown`, `mq.xsDown`) alongside the existing upward ones. All 30+ component and route stylesheets that imported from the old path have been updated to the new location. A shared `grid.css.js` module now provides the `.grid` utility class with responsive column counts driven by CSS custom properties, and `container.css.js` was moved into the same `layout/` folder to keep layout primitives co-located.

---

## Grid and Container Showcase Stories

Two new Storybook-style stories — `grid.js` and `container.js` — have been added to the showcase route to document and visually test the layout utilities. The grid story exercises every column variant, gap token, and the `--grid-cols` override mechanism. The container story demonstrates max-width clamping and inline padding behaviour across viewport widths. The showcase route's styles were substantially expanded to render these stories with labeled captions and live resize feedback.

---

## Game Catalog Toolbar Grid

The `#toolbar` was converted from a `flex` row to a named-area CSS grid (`count | search | sort`). The collapse button column is intentionally absent from the default template; it is injected only when the sticky band enters the `is-expanded` state on mobile, so no phantom gap appears when the button is hidden. The same principle applies to the two-row mobile layout (`mdDown`): the default is a 2×2 grid without a collapse column, and the third column is added only in the expanded variant. The "SORT BY" label is hidden below 480 px via `mq.xsDown` to recover horizontal space on small phones.

---

## Filter Group and Sort Bar Refinements

The `ui-filter-group` component's accent color propagation was fixed to target the `#choices` wrapper element rather than `$select.parentElement`, ensuring the color reaches both the tab strip and the native select. Color-keyed tab buttons now use `::after` for the swatch dot (moved from `::before`) so it trails the label, and hover/active states for color-keyed tabs are handled by dedicated selectors that read from `--filter-item-color`. The mobile breakpoint that hides tabs was widened from `mq.sm` to `mq.mdDown` for consistency. In the game route, the Rarity sort button is disabled while a rarity filter is active (the two controls are mutually exclusive), and sort order was changed to Price → Rarity to match visual left-to-right priority.

---

## Mobile Sticky Pill and Collapse Refactor

The `connectedCallback` sticky-band setup was split into four focused private methods (`_setupStickyObserver`, `_setupPillExpand`, `_setupPillSegments`, `_setupCollapseControls`) to reduce nesting and make each concern independently readable. The collapse animation was rewritten as a two-frame technique: frame 1 pins the current rendered pixel width as an inline style and removes `is-expanded`; frame 2 measures the pill's natural `fit-content` width and writes it as the transition target. The inline SVG search icon and mask-based collapse chevron were both replaced with `ui-svg` component references. An empty-state paragraph (`#items-empty`) now appears with a localized message when filtering returns no results, backed by new `all.yaml` and `noItemsFound.yaml` i18n files covering all 19 locales.

---

## Test Plan

- [ ] Desktop (≥1024 px): toolbar shows count, search, and sort with no extra trailing gap after sort buttons
- [ ] Tablet (768–1023 px): toolbar switches to 2-row layout; search fills row 1, count and sort share row 2 with no trailing gap
- [ ] Mobile (<768 px): scroll past hero — sticky band collapses to pill; tap pill — band expands and collapse button appears in the third column slot
- [ ] Mobile expanded: tap the chevron collapse button — band animates back to pill width smoothly
- [ ] Mobile expanded: tap outside the sticky band — band collapses
- [ ] <480 px: "SORT BY" label is hidden; sort buttons remain visible and functional
- [ ] Filter by rarity — Rarity sort button becomes disabled; clearing rarity filter re-enables it
- [ ] Filter by type + search term that matches nothing — localized "No items found" message appears
- [ ] Switch locale (e.g. fr, ja) — "No items found" message renders in the correct language
- [ ] Color-keyed rarity filter tabs: hover shows item color, active applies background glow, accent propagates correctly to the tab strip
- [ ] Showcase route: Grid and Container stories render without visual errors at mobile, tablet, and desktop widths
- [ ] All themes (dark, light, cyberpunk): toolbar, pill, and filter-group render without hard-coded color bleed
