### PR TITLE
refactor(ui): fold item count into ui-search, flexbox toolbar, and type scale expansion

### DIFF
--- a/src/UI/components/filter-group/index.js
+++ b/src/UI/components/filter-group/index.js
@@ -94,7 +94,7 @@ export class FILTER_GROUP extends Component {
         const overflowCount = Math.max(0, this._options.length - maxV)
         if (overflowCount > 0) {
             const toggle = document.createElement("button")
-            toggle.className = "filter-tabs__toggle"
+            toggle.className = "filter-tabs__toggle btn-load-more"
             toggle.textContent = `+${overflowCount} more`
             toggle.addEventListener("click", () => {
                 const expanded = this.$tabs.classList.toggle("expanded")

--- a/src/UI/components/filter-group/styles.css.js
+++ b/src/UI/components/filter-group/styles.css.js
@@ -10,7 +10,7 @@ export const styles = css`
         display: flex;
         align-items: flex-start;
         gap: var(--space-3);
-        padding: var(--space-2) var(--space-3);
+        padding: var(--space-3);
     }
 
     :host([bordered]) .filter-group {
@@ -20,9 +20,9 @@ export const styles = css`
     .filter-group__label {
         flex-shrink: 0;
         width: 3.5rem;
-        padding-top: calc(var(--space-1) + 1px);
+        align-self: center;
         font-family: var(--header-font);
-        font-size: var(--text-xs);
+        font-size: var(--text-2xs);
         letter-spacing: 0.1em;
         text-transform: uppercase;
         color: var(--color);
@@ -36,9 +36,11 @@ export const styles = css`
 
     /* ── Tabs (default pill/button style, desktop) ── */
     .filter-tabs {
+        position: relative;
         display: flex;
         flex-wrap: wrap;
         gap: var(--space-1);
+        padding-right: var(--filter-toggle-width, 6rem);
 
         /* hide overflow buttons when not expanded */
         &:not(.expanded) [data-overflow] {
@@ -82,13 +84,12 @@ export const styles = css`
             content: "";
             display: inline-block;
             flex-shrink: 0;
-            width: 0.5em;
-            height: 0.5em;
+            width: 0.7em;
+            height: 0.7em;
             border-radius: 50%;
             background: var(--filter-item-color, var(--color));
             opacity: 0.7;
             margin-left: 0.3em;
-            vertical-align: middle;
             transition: opacity var(--speed);
         }
 
@@ -113,9 +114,12 @@ export const styles = css`
         }
     }
 
-    /* Toggle "show more / less" button */
+    /* Toggle "show more / less" button — always pinned to top-right of the tabs row */
     .filter-tabs__toggle {
-        margin-left: auto;
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        right: 0;
         flex-shrink: 0;
         font-family: var(--header-font);
         font-size: var(--text-xs);
@@ -134,7 +138,9 @@ export const styles = css`
         transition:
             opacity var(--speed),
             text-decoration-color var(--speed);
-
+        &.btn-load-more {
+            padding-right: 0;
+        }
         &:hover {
             opacity: 1;
             text-decoration-color: var(--accent-action);

--- a/src/UI/components/search/index.js
+++ b/src/UI/components/search/index.js
@@ -31,7 +31,7 @@ export class SEARCH extends Component {
     }
 
     static get observedAttributes() {
-        return ["placeholder", "value", "min-chars"]
+        return ["placeholder", "value", "min-chars", "count"]
     }
 
     attributeChangedCallback(name, _, next) {
@@ -42,6 +42,10 @@ export class SEARCH extends Component {
         if (name === "value") {
             const input = this.shadowRoot?.querySelector(".search-input")
             if (input && input.value !== next) input.value = next || ""
+        }
+        if (name === "count") {
+            const span = this.shadowRoot?.querySelector(".search-count")
+            if (span) span.textContent = next ?? ""
         }
     }
 
@@ -57,13 +61,16 @@ export class SEARCH extends Component {
     onconnect() {
         this.$input = this.shadowRoot.querySelector(".search-input")
         this.$list = this.shadowRoot.querySelector(".search-suggestions")
+        this.$count = this.shadowRoot.querySelector(".search-count")
 
-        // Reflect placeholder attribute set before connect
         const ph = this.getAttribute("placeholder")
         if (ph) this.$input.placeholder = ph
 
         const val = this.getAttribute("value")
         if (val) this.$input.value = val
+
+        const count = this.getAttribute("count")
+        if (count) this.$count.textContent = count
 
         this.$input.addEventListener("input", this._onInput.bind(this))
         this.$input.addEventListener("focus", this._onFocus.bind(this))

--- a/src/UI/components/search/styles.css.js
+++ b/src/UI/components/search/styles.css.js
@@ -10,6 +10,33 @@ export const styles = css`
         position: relative;
     }
 
+    .search-count {
+        position: absolute;
+        right: var(--space-3);
+        top: 50%;
+        transform: translateY(-50%);
+        font-family: var(--header-font);
+        font-size: var(--text-xs);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--search-count-color, var(--neon-c));
+        text-shadow: var(--search-count-glow, var(--glow-c));
+        pointer-events: none;
+        white-space: nowrap;
+
+        &::after {
+            content: " " var(--search-count-label, "ITEMS");
+            color: var(--color);
+            text-shadow: none;
+            opacity: 0.35;
+            font-size: var(--text-2xs);
+        }
+
+        &:empty {
+            display: none;
+        }
+    }
+
     .search-input {
         width: 100%;
         background: transparent;
@@ -19,6 +46,7 @@ export const styles = css`
         font-size: var(--text-sm);
         letter-spacing: 0.06em;
         padding: var(--space-2) var(--space-3);
+        padding-right: var(--search-count-offset, var(--space-3));
         outline: none;
         transition:
             border-color var(--speed),

--- a/src/UI/components/search/template.js
+++ b/src/UI/components/search/template.js
@@ -5,6 +5,7 @@ export const template = html`
     ${styles}
     <div class="search-wrap">
         <input class="search-input" type="search" autocomplete="off" spellcheck="false" />
+        <span class="search-count" aria-hidden="true"></span>
         <ul class="search-suggestions" role="listbox" aria-label="Suggestions"></ul>
     </div>
 `

--- a/src/UI/css/layout/grid.css.js
+++ b/src/UI/css/layout/grid.css.js
@@ -1,5 +1,5 @@
 import { css } from "/core/UI.js"
-import { bp, mq } from "/UI/css/layout/breakpoints.js"
+import { mq } from "/UI/css/layout/breakpoints.js"
 
 /**
  * Shared grid patterns. Import and apply the class to any container.

--- a/src/UI/css/vars.css.js
+++ b/src/UI/css/vars.css.js
@@ -36,11 +36,12 @@ export const styles = css`
         /* Typography — fluid via clamp(min, viewport, max).
            Max values match the previous fixed sizes (0.125rem × multiplier).
            Min values keep text legible on small phones. */
-        --text-xs: clamp(0.65rem, 1.5vw, 0.75rem);
-        --text-sm: clamp(0.75rem, 1.8vw, 0.875rem);
-        --text-md: clamp(0.875rem, 2vw, 1rem);
-        --text-lg: clamp(1rem, 2.5vw, 1.25rem);
-        --text-xl: clamp(1.25rem, 3vw, 1.5rem);
+        --text-2xs: clamp(0.65rem, 1vw, 0.7rem); /* Status labels/tooltips */
+        --text-xs: clamp(0.75rem, 1.2vw, 0.8rem); /* Secondary info */
+        --text-sm: clamp(0.8rem, 1.5vw, 0.9rem); /* Metadata */
+        --text-md: clamp(0.9rem, 2vw, 1rem); /* Base Body Text */
+        --text-lg: clamp(1.05rem, 2.5vw, 1.25rem); /* Item Names */
+        --text-xl: clamp(1.35rem, 3.5vw, 1.75rem); /* Titles */
         --text: var(--text-md);
 
         /* Animation */

--- a/src/UI/routes/game/[game]/index.js
+++ b/src/UI/routes/game/[game]/index.js
@@ -277,8 +277,8 @@ export class GAME extends HTMLElement {
 
         // Count — when browsing without a filter, show the catalog total immediately
         // so the number doesn't flicker as background pages load in
-        const countEl = this.shadowRoot.querySelector("#count-num")
-        if (countEl) countEl.textContent = countValue
+        const searchEl = this.shadowRoot.querySelector("#search")
+        if (searchEl) searchEl.setAttribute("count", countValue)
 
         // ── Sync collapsed pill ──
         const pillType = this.shadowRoot.querySelector("#pill-type")

--- a/src/UI/routes/game/[game]/styles.css.js
+++ b/src/UI/routes/game/[game]/styles.css.js
@@ -24,7 +24,7 @@ export const styles = css`
             margin-top: calc(-1 * var(--space-4));
             /* Inner content alignment: mirrors layout-main's centering formula */
             padding-top: calc(var(--space-4) + var(--hero-pad-top));
-            padding-bottom: var(--space-6);
+            padding-bottom: var(--space-3);
             padding-inline: max(var(--space-2), calc((100vw - var(--max-width, 80rem)) / 2));
             display: flex;
             flex-direction: column;
@@ -73,7 +73,7 @@ export const styles = css`
                 font-size: var(--text-md);
                 color: var(--color);
                 opacity: 0.6;
-                max-width: 56rem;
+                max-width: 42rem;
                 line-height: 1.6;
             }
 
@@ -95,6 +95,7 @@ export const styles = css`
         /* ── Sticky sentinel ── */
         .sticky-sentinel {
             height: 1px;
+            margin-top: calc(-1 * var(--space-6));
             margin-bottom: -1px;
             pointer-events: none;
         }
@@ -132,7 +133,6 @@ export const styles = css`
             display: flex;
             flex-direction: column;
             gap: 0;
-            padding-block: var(--space-3);
             border: 1px solid transparent;
         }
 
@@ -151,13 +151,12 @@ export const styles = css`
             }
         }
 
-        #toolbar {
-            display: grid;
-            grid-template-columns: auto 1fr auto;
-            grid-template-areas: "count search sort";
+        .catalog-toolbar {
+            display: flex;
             align-items: center;
+            flex-wrap: wrap;
             gap: var(--space-3);
-            padding: var(--space-3) var(--space-4) var(--space-4);
+            padding: var(--space-3);
             margin: 0;
             background: color-mix(in hsl, var(--color) 3%, transparent);
             transition:
@@ -170,19 +169,16 @@ export const styles = css`
                 animation: toolbar-pulse var(--speed-2) ease forwards;
             }
 
-            .catalog-count {
-                grid-area: count;
-                line-height: normal;
-            }
             ui-search {
-                grid-area: search;
+                flex: 1;
                 min-width: 0;
             }
             .sort-bar {
-                grid-area: sort;
+                flex-shrink: 0;
             }
             .catalog-collapse-btn {
-                grid-area: collapse;
+                flex-shrink: 0;
+                margin-left: auto;
             }
         }
 
@@ -196,14 +192,6 @@ export const styles = css`
             padding-left: var(--space-1);
             color: var(--color);
             opacity: 0.4;
-        }
-
-        .catalog-count {
-            flex-shrink: 0;
-            align-self: center;
-            ${labelFont}
-            letter-spacing: 0.08em;
-            white-space: nowrap;
         }
 
         /* ── Search wrap + autocomplete ── */
@@ -321,25 +309,29 @@ export const styles = css`
 
         .sort-bar {
             display: flex;
+            align-items: center;
             justify-content: flex-end;
             flex-wrap: wrap;
-            gap: var(--space-1);
+            gap: var(--space-3);
         }
 
         .sort-bar__label {
-            padding-inline: var(--space-1) var(--space-2);
             color: var(--color);
             opacity: 0.4;
             font-family: var(--header-font);
-            font-size: var(--text-xs);
+            font-size: var(--text-2xs);
             text-transform: uppercase;
             letter-spacing: 0.08em;
             white-space: nowrap;
             align-self: center;
             line-height: normal;
 
-            @media ${mq.xsDown} {
+            @media (max-width: 429.98px) {
                 display: none;
+            }
+
+            @media ${mq.mdDown} {
+                padding-left: 0;
             }
         }
 
@@ -406,7 +398,7 @@ export const styles = css`
 
         .catalog-grid {
             --grid-cols: 3;
-            padding: var(--space-4) 0 var(--space-3);
+            padding: var(--space-3) 0 var(--space-3);
         }
 
         ui-loader {
@@ -421,22 +413,15 @@ export const styles = css`
 
         /* mdDown: tablet and below (<768px) */
         @media ${mq.mdDown} {
-            .game-hero {
-                padding-bottom: var(--space-5);
-            }
         }
 
         /* smDown: small phones and below (<576px) */
         @media ${mq.smDown} {
-            .game-hero {
-                padding-bottom: var(--space-4);
-            }
         }
 
         /* xsDown: extra small phones (<480px) */
         @media ${mq.xsDown} {
             .game-hero {
-                padding-bottom: var(--space-3);
                 gap: var(--space-1);
 
                 h1 {
@@ -453,15 +438,21 @@ export const styles = css`
             }
         }
 
-        /* mdDown: toolbar switches to 2-row grid — search full-width on row 1 */
+        /* mdDown: search full-width on row 1, sort + collapse share row 2 */
         @media ${mq.mdDown} {
-            #toolbar {
-                grid-template-columns: auto 1fr;
-                grid-template-rows: auto auto;
-                grid-template-areas:
-                    "search  search"
-                    "count   sort";
+            .catalog-toolbar {
                 padding: var(--space-3);
+
+                ui-search {
+                    flex-basis: 100%;
+                }
+                .sort-bar {
+                    flex: 1;
+                    justify-content: flex-start;
+                }
+                .catalog-collapse-btn {
+                    margin-left: 0;
+                }
             }
         }
 
@@ -474,7 +465,7 @@ export const styles = css`
                 border-radius: 0 0 8px 0;
                 cursor: pointer;
                 .marketplace-nav,
-                #toolbar {
+                .catalog-toolbar {
                     display: none;
                 }
 
@@ -502,17 +493,7 @@ export const styles = css`
                     display: none;
                 }
 
-                #toolbar {
-                    grid-template-columns: auto 1fr auto auto;
-                    grid-template-areas: "count search sort collapse";
-
-                    @media ${mq.mdDown} {
-                        grid-template-columns: auto 1fr auto;
-                        grid-template-areas:
-                            "search  search   search"
-                            "count   sort     collapse";
-                    }
-                }
+                /* collapse button becomes visible — no layout change needed */
 
                 .catalog-collapse-btn {
                     display: flex;
@@ -676,6 +657,10 @@ export const styles = css`
             align-items: center;
             justify-content: center;
             min-height: 160px;
+
+            &[hidden] {
+                display: none;
+            }
             font-family: var(--header-font);
             font-size: var(--text-sm);
             letter-spacing: 0.08em;
@@ -688,10 +673,10 @@ export const styles = css`
         .load-more-wrap {
             display: flex;
             justify-content: center;
-            padding: var(--space-4) 0 var(--space-6);
         }
 
         .load-more-btn {
+            margin: var(--space-3) 0 var(--space-6);
             ${labelFont}
             letter-spacing: 0.12em;
             padding: var(--space-2) var(--space-6);

--- a/src/UI/routes/game/[game]/template.js
+++ b/src/UI/routes/game/[game]/template.js
@@ -36,6 +36,7 @@ export const template = html`
                     <ui-svg data-src="/images/icons/search.svg"></ui-svg>
                 </span>
             </div>
+
             <nav class="marketplace-nav">
                 <ui-filter-group id="type-filter">
                     <span slot="label">Type</span>
@@ -46,10 +47,6 @@ export const template = html`
             </nav>
 
             <div class="catalog-toolbar" id="toolbar">
-                <span class="catalog-count" id="count">
-                    <span class="count__num" id="count-num"></span>
-                    <span class="count__label">Items</span>
-                </span>
                 <ui-search id="search" placeholder="Search items…"></ui-search>
                 <div class="sort-bar" id="sort"></div>
                 <button class="catalog-collapse-btn" id="catalog-collapse" aria-label="Collapse filters">

--- a/src/UI/routes/pools/styles.css.js
+++ b/src/UI/routes/pools/styles.css.js
@@ -196,7 +196,7 @@ export const styles = css`
         .filter-group__label {
             flex-shrink: 0;
             font-family: var(--header-font);
-            font-size: var(--text-xs);
+            font-size: var(--text-2xs);
             letter-spacing: 0.12em;
             text-transform: uppercase;
             opacity: 0.35;


### PR DESCRIPTION
## Summary

This PR consolidates the catalog item count from a standalone DOM element into `ui-search` as a new `count` attribute overlay, replaces the game catalog toolbar's named-area grid with a wrapping flexbox, and expands the type scale with a new `--text-2xs` token — together eliminating layout gymnastics that required separate grid rewrites per breakpoint and per collapse state.

---

## `ui-search` count overlay

`ui-search` gains a `count` observed attribute that renders an absolutely-positioned `.search-count` span inside the input wrapper. The number is styled with `--neon-c` and a configurable `--search-count-glow`, and the "ITEMS" label appended via `::after` uses `--search-count-label` so consumers can override it without touching the component. The span hides itself when empty so no layout space is reserved when no count is set. The input's `padding-right` is driven by `--search-count-offset` so the typed text never collides with the overlay. The game route's count update now calls `searchEl.setAttribute("count", countValue)` instead of writing directly into the old `#count-num` span.

---

## Catalog toolbar: grid → flexbox

The `#toolbar` named-area grid (`"count search sort"` / `"search search" / "count sort"`) has been replaced with a `flex-wrap: wrap` row on `.catalog-toolbar`. `ui-search` takes `flex: 1`, the sort bar and collapse button are `flex-shrink: 0`, and the collapse button uses `margin-left: auto` to push right on desktop. At `mdDown`, `ui-search` gets `flex-basis: 100%` to break onto its own row while sort and collapse share the second row — no separate grid-template-areas rewrite needed. The collapsed state now simply hides `.catalog-toolbar` rather than redefining its grid, reducing the collapse override block to a comment.

---

## Type scale and filter-group polish

`vars.css.js` adds `--text-2xs` (`clamp(0.65rem, 1vw, 0.7rem)`) for status labels and tooltips, and tightens the existing steps so the scale is more evenly distributed from `2xs` through `xl`. The `filter-group` label switches to `--text-2xs` and vertically centers with `align-self: center` instead of a manual `padding-top` offset. The overflow toggle button is now absolutely positioned at the right edge of the `.filter-tabs` row (which gains `position: relative` and a reserved `padding-right`) instead of relying on `margin-left: auto` — making it immune to reflow when filters wrap across lines. The `pools` route filter label adopts `--text-2xs` for consistency.

---

## Test Plan

- [ ] Game catalog toolbar renders correctly at full desktop width — search bar fills available space, sort controls sit right, no count span visible as a standalone element
- [ ] Item count appears as an overlay inside the search input and updates reactively when the catalog loads
- [ ] At tablet width (768–1023px), search expands to full row width; sort and collapse share the second row
- [ ] At mobile width (<480px), sort label hides; layout does not overflow or clip
- [ ] Collapsed catalog state hides the toolbar and filter nav; expanding restores them without layout shift
- [ ] `ui-filter-group` overflow toggle stays pinned to the right edge when multiple filter pills wrap to a second line
- [ ] `--text-2xs` token renders visibly smaller than `--text-xs` across light, dark, and cyberpunk themes
- [ ] Pools route filter group label renders at the new smaller size without misalignment
